### PR TITLE
32bits mask is faster

### DIFF
--- a/jaq-inabox/src/main/java/io/jaq/spsc/FFBuffer.java
+++ b/jaq-inabox/src/main/java/io/jaq/spsc/FFBuffer.java
@@ -29,7 +29,7 @@ class FFBufferColdFields<E> extends FFBufferL0Pad {
     protected static final int BUFFER_PAD = 32;
     protected static final int SPARSE_SHIFT = Integer.getInteger("sparse.shift", 2);
     protected final int capacity;
-    protected final long mask;
+    protected final int mask;
     protected final E[] buffer;
     @SuppressWarnings("unchecked")
     public FFBufferColdFields(int capacity) {
@@ -110,7 +110,7 @@ public final class FFBuffer<E> extends FFBufferL3Pad<E> implements Queue<E> {
         throw new IllegalStateException("Queue is full");
     }
     private long offset(long index) {
-        return ARRAY_BASE + ((index & mask) << ELEMENT_SHIFT);
+        return ARRAY_BASE + (((int) index & mask) << ELEMENT_SHIFT);
     }
     public boolean offer(final E e) {
         if (null == e) {

--- a/jaq-inabox/src/main/java/io/jaq/spsc/FFBufferWithOfferBatch.java
+++ b/jaq-inabox/src/main/java/io/jaq/spsc/FFBufferWithOfferBatch.java
@@ -34,7 +34,7 @@ class FFBufferOfferBatchColdFields<E> extends FFBufferOfferBatchL0Pad {
     protected static final int BUFFER_PAD = 32;
     protected static final int SPARSE_SHIFT = Integer.getInteger("sparse.shift", 2);
     protected final int capacity;
-    protected final long mask;
+    protected final int mask;
     protected final E[] buffer;
     @SuppressWarnings("unchecked")
     public FFBufferOfferBatchColdFields(int capacity) {
@@ -117,7 +117,7 @@ public final class FFBufferWithOfferBatch<E> extends FFBufferOfferBatchL3Pad<E> 
         throw new IllegalStateException("Queue is full");
     }
     private long offset(long index) {
-        return ARRAY_BASE + ((index & mask) << ELEMENT_SHIFT);
+        return ARRAY_BASE + (((int) index & mask) << ELEMENT_SHIFT);
     }
     public boolean offer(final E e) {
         if (null == e) {

--- a/jaq-inabox/src/main/java/io/jaq/spsc/FFBufferWithOfferBatchCq.java
+++ b/jaq-inabox/src/main/java/io/jaq/spsc/FFBufferWithOfferBatchCq.java
@@ -31,7 +31,7 @@ abstract class FFBufferOfferBatchCqColdFields<E> extends FFBufferOfferBatchCqPad
     protected static final int SPARSE_SHIFT = Integer.getInteger("sparse.shift", 2);
     protected static final int OFFER_BATCH_SIZE = Integer.getInteger("offer.batch.size", 4096);
     protected final int capacity;
-    protected final long mask;
+    protected final int mask;
     protected final E[] buffer;
     protected ConcurrentQueueConsumer<E> consumer;
     protected ConcurrentQueueProducer<E> producer;
@@ -107,7 +107,7 @@ public final class FFBufferWithOfferBatchCq<E> extends FFBufferOfferBatchCqColdF
         }
 
         private long offset(long index) {
-            return ARRAY_BASE + ((index & mask) << ELEMENT_SHIFT);
+            return ARRAY_BASE + (((int) index & mask) << ELEMENT_SHIFT);
         }
 
         @Override


### PR DESCRIPTION
Thanks Martin Thompson - got this from an old talk he made.

I have measured the impact with JMH and it's 10% faster to offer()
A little bit less under concurrent offer/poll
