### PR TITLE
Queues rewritten with plain JDK atomics for platforms without Unsafe.

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicQueueFactory.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicQueueFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.jctools.queues.MpscCompoundQueue;
+import org.jctools.queues.spec.ConcurrentQueueSpec;
+import org.jctools.queues.spec.Ordering;
+
+/**
+ * The queue factory produces {@link java.util.Queue} instances based on a best fit to the {@link ConcurrentQueueSpec}.
+ * This allows minimal dependencies between user code and the queue implementations and gives users a way to express
+ * their requirements on a higher level.
+ * 
+ * @author nitsanw
+ * @author akarnokd
+ * 
+ */
+public class AtomicQueueFactory {
+
+    public static <E> Queue<E> newQueue(ConcurrentQueueSpec qs) {
+        if (qs.isBounded()) {
+            // SPSC
+            if (qs.isSpsc()) {
+                return new SpscAtomicArrayQueue<E>(qs.capacity);
+            }
+            // MPSC
+            else if (qs.isMpsc()) {
+                if (qs.ordering != Ordering.NONE) {
+                    return new MpscAtomicArrayQueue<E>(qs.capacity);
+                } else {
+                    return new MpscCompoundQueue<E>(qs.capacity);
+                }
+            }
+            // SPMC
+            else if (qs.isSpmc()) {
+                return new SpmcAtomicArrayQueue<E>(qs.capacity);
+            }
+            // MPMC
+            else {
+                return new MpmcAtomicArrayQueue<E>(qs.capacity);
+            }
+        } else {
+            // SPSC
+            if (qs.isSpsc()) {
+                return new SpscLinkedAtomicQueue<E>();
+            }
+            // MPSC
+            else if (qs.isMpsc()) {
+                return new MpscLinkedAtomicQueue<E>();
+            }
+        }
+        return new ConcurrentLinkedQueue<E>();
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicReferenceArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicReferenceArrayQueue.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import org.jctools.util.Pow2;
+
+abstract class AtomicReferenceArrayQueue<E> extends AbstractQueue<E> {
+    protected final AtomicReferenceArray<E> buffer;
+    protected final int mask;
+    public AtomicReferenceArrayQueue(int capacity) {
+        int actualCapacity = Pow2.roundToPowerOfTwo(capacity);
+        this.mask = actualCapacity - 1;
+        this.buffer = new AtomicReferenceArray<E>(actualCapacity);
+    }
+    @Override
+    public Iterator<E> iterator() {
+        throw new UnsupportedOperationException();
+    }
+    @Override
+    public void clear() {
+        // we have to test isEmpty because of the weaker poll() guarantee
+        while (poll() != null || !isEmpty())
+            ;
+    }
+    protected int calcElementOffset(long index, int mask) {
+        return (int)index & mask;
+    }
+    protected int calcElementOffset(long index) {
+        return (int)index & mask;
+    }
+    protected E lvElement(AtomicReferenceArray<E> buffer, int offset) {
+        return buffer.get(offset);
+    }
+    protected E lpElement(AtomicReferenceArray<E> buffer, int offset) {
+        return buffer.get(offset); // no weaker form available
+    }
+    protected E lpElement(int offset) {
+        return buffer.get(offset); // no weaker form available
+    }
+    protected void spElement(AtomicReferenceArray<E> buffer, int offset, E value) {
+        buffer.lazySet(offset, value);  // no weaker form available
+    }
+    protected void spElement(int offset, E value) {
+        buffer.lazySet(offset, value);  // no weaker form available
+    }
+    protected void soElement(AtomicReferenceArray<E> buffer, int offset, E value) {
+        buffer.lazySet(offset, value);
+    }
+    protected void soElement(int offset, E value) {
+        buffer.lazySet(offset, value);
+    }
+    protected void svElement(AtomicReferenceArray<E> buffer, int offset, E value) {
+        buffer.set(offset, value);
+    }
+    protected E lvElement(int offset) {
+        return lvElement(buffer, offset);
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/BaseLinkedAtomicQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/BaseLinkedAtomicQueue.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+
+abstract class BaseLinkedAtomicQueue<E> extends AbstractQueue<E> {
+    private final AtomicReference<LinkedQueueAtomicNode<E>> producerNode;
+    private final AtomicReference<LinkedQueueAtomicNode<E>> consumerNode;
+    public BaseLinkedAtomicQueue() {
+        producerNode = new AtomicReference<LinkedQueueAtomicNode<E>>();
+        consumerNode = new AtomicReference<LinkedQueueAtomicNode<E>>();
+    }
+    protected final LinkedQueueAtomicNode<E> lvProducerNode() {
+        return producerNode.get();
+    }
+    protected final LinkedQueueAtomicNode<E> lpProducerNode() {
+        return producerNode.get();
+    }
+    protected final void spProducerNode(LinkedQueueAtomicNode<E> node) {
+        producerNode.lazySet(node);
+    }
+    protected final LinkedQueueAtomicNode<E> xchgProducerNode(LinkedQueueAtomicNode<E> node) {
+        return producerNode.getAndSet(node);
+    }
+    protected final LinkedQueueAtomicNode<E> lvConsumerNode() {
+        return consumerNode.get();
+    }
+    
+    protected final LinkedQueueAtomicNode<E> lpConsumerNode() {
+        return consumerNode.get();
+    }
+    protected final void spConsumerNode(LinkedQueueAtomicNode<E> node) {
+        consumerNode.lazySet(node);
+    }
+    @Override
+    public final Iterator<E> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc} <br>
+     * <p>
+     * IMPLEMENTATION NOTES:<br>
+     * This is an O(n) operation as we run through all the nodes and count them.<br>
+     * 
+     * @see java.util.Queue#size()
+     */
+    @Override
+    public final int size() {
+        LinkedQueueAtomicNode<E> chaserNode = lvConsumerNode();
+        final LinkedQueueAtomicNode<E> producerNode = lvProducerNode();
+        int size = 0;
+        // must chase the nodes all the way to the producer node, but there's no need to chase a moving target.
+        while (chaserNode != producerNode && size < Integer.MAX_VALUE) {
+            LinkedQueueAtomicNode<E> next;
+            while((next = chaserNode.lvNext()) == null);
+            chaserNode = next;
+            size++;
+        }
+        return size;
+    }
+    /**
+     * {@inheritDoc} <br>
+     * <p>
+     * IMPLEMENTATION NOTES:<br>
+     * Queue is empty when producerNode is the same as consumerNode. An alternative implementation would be to observe
+     * the producerNode.value is null, which also means an empty queue because only the consumerNode.value is allowed to
+     * be null.
+     * 
+     * @see MessagePassingQueue#isEmpty()
+     */
+    @Override
+    public final boolean isEmpty() {
+        return lvConsumerNode() == lvProducerNode();
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/LinkedQueueAtomicNode.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/LinkedQueueAtomicNode.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class LinkedQueueAtomicNode<E> extends AtomicReference<LinkedQueueAtomicNode<E>> {
+    /** */
+    private static final long serialVersionUID = 2404266111789071508L;
+    private E value;
+    LinkedQueueAtomicNode() {
+    }
+    LinkedQueueAtomicNode(E val) {
+        spValue(val);
+    }
+    /**
+     * Gets the current value and nulls out the reference to it from this node.
+     * 
+     * @return value
+     */
+    public E getAndNullValue() {
+        E temp = lpValue();
+        spValue(null);
+        return temp;
+    }
+
+    public E lpValue() {
+        return value;
+    }
+
+    public void spValue(E newValue) {
+        value = newValue;
+    }
+
+    public void soNext(LinkedQueueAtomicNode<E> n) {
+        lazySet(n);
+    }
+
+    public LinkedQueueAtomicNode<E> lvNext() {
+        return get();
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpmcAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpmcAtomicArrayQueue.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+
+import org.jctools.queues.QueueProgressIndicators;
+
+public class MpmcAtomicArrayQueue<E> extends SequencedAtomicReferenceArrayQueue<E>
+        implements QueueProgressIndicators {
+    private final AtomicLong producerIndex;
+    private final AtomicLong consumerIndex;
+
+    public MpmcAtomicArrayQueue(int capacity) {
+        super(validateCapacity(capacity));
+        this.producerIndex = new AtomicLong();
+        this.consumerIndex = new AtomicLong();
+    }
+
+    private static int validateCapacity(int capacity) {
+        if(capacity < 2)
+            throw new IllegalArgumentException("Minimum size is 2");
+        return capacity;
+    }
+
+    @Override
+    public boolean offer(final E e) {
+        if (null == e) {
+            throw new NullPointerException("Null is not a valid element");
+        }
+
+        // local load of field to avoid repeated loads after volatile reads
+        final int mask = this.mask;
+        final int capacity = mask + 1;
+        final AtomicLongArray sBuffer = sequenceBuffer;
+        long currentProducerIndex;
+        int seqOffset;
+        long cIndex = Long.MAX_VALUE;// start with bogus value, hope we don't need it
+        while (true) {
+            currentProducerIndex = lvProducerIndex(); // LoadLoad
+            seqOffset = calcSequenceOffset(currentProducerIndex, mask);
+            final long seq = lvSequence(sBuffer, seqOffset); // LoadLoad
+            final long delta = seq - currentProducerIndex;
+
+            if (delta == 0) {
+                // this is expected if we see this first time around
+                if (casProducerIndex(currentProducerIndex, currentProducerIndex + 1)) {
+                    // Successful CAS: full barrier
+                    break;
+                }
+                // failed cas, retry 1
+            } else if (delta < 0 && // poll has not moved this value forward
+                    currentProducerIndex - capacity <= cIndex && // test against cached cIndex
+                    currentProducerIndex - capacity <= (cIndex = lvConsumerIndex())) { // test against latest cIndex
+                // Extra check required to ensure [Queue.offer == false iff queue is full]
+                return false;
+            }
+
+            // another producer has moved the sequence by one, retry 2
+        }
+
+        // on 64bit(no compressed oops) JVM this is the same as seqOffset
+        final int elementOffset = calcElementOffset(currentProducerIndex, mask);
+        spElement(elementOffset, e);
+
+        // increment sequence by 1, the value expected by consumer
+        // (seeing this value from a producer will lead to retry 2)
+        soSequence(sBuffer, seqOffset, currentProducerIndex + 1); // StoreStore
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Because return null indicates queue is empty we cannot simply rely on next element visibility for poll
+     * and must test producer index when next element is not visible.
+     */
+    @Override
+    public E poll() {
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicLongArray lSequenceBuffer = sequenceBuffer;
+        final int mask = this.mask;
+        long currentConsumerIndex;
+        int seqOffset;
+        long pIndex = -1; // start with bogus value, hope we don't need it
+        while (true) {
+            currentConsumerIndex = lvConsumerIndex();// LoadLoad
+            seqOffset = calcSequenceOffset(currentConsumerIndex, mask);
+            final long seq = lvSequence(lSequenceBuffer, seqOffset);// LoadLoad
+            final long delta = seq - (currentConsumerIndex + 1);
+
+            if (delta == 0) {
+                if (casConsumerIndex(currentConsumerIndex, currentConsumerIndex + 1)) {
+                    // Successful CAS: full barrier
+                    break;
+                }
+                // failed cas, retry 1
+            } else if (delta < 0 && // slot has not been moved by producer
+                    currentConsumerIndex >= pIndex && // test against cached pIndex
+                    currentConsumerIndex == (pIndex = lvProducerIndex())) { // update pIndex if we must
+                // strict empty check, this ensures [Queue.poll() == null iff isEmpty()]
+                return null;
+            }
+
+            // another consumer beat us and moved sequence ahead, retry 2
+        }
+
+        // on 64bit(no compressed oops) JVM this is the same as seqOffset
+        final int offset = calcElementOffset(currentConsumerIndex, mask);
+        final E e = lpElement(offset);
+        spElement(offset, null);
+
+        // Move sequence ahead by capacity, preparing it for next offer
+        // (seeing this value from a consumer will lead to retry 2)
+        soSequence(lSequenceBuffer, seqOffset, currentConsumerIndex + mask + 1);// StoreStore
+
+        return e;
+    }
+
+    @Override
+    public E peek() {
+        long currConsumerIndex;
+        E e;
+        do {
+            currConsumerIndex = lvConsumerIndex();
+            // other consumers may have grabbed the element, or queue might be empty
+            e = lpElement(calcElementOffset(currConsumerIndex));
+            // only return null if queue is empty
+        } while (e == null && currConsumerIndex != lvProducerIndex());
+        return e;
+    }
+
+    @Override
+    public int size() {
+        /*
+         * It is possible for a thread to be interrupted or reschedule between the read of the producer and
+         * consumer indices, therefore protection is required to ensure size is within valid range. In the
+         * event of concurrent polls/offers to this method the size is OVER estimated as we read consumer
+         * index BEFORE the producer index.
+         */
+        long after = lvConsumerIndex();
+        while (true) {
+            final long before = after;
+            final long currentProducerIndex = lvProducerIndex();
+            after = lvConsumerIndex();
+            if (before == after) {
+                return (int) (currentProducerIndex - after);
+            }
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        // Order matters!
+        // Loading consumer before producer allows for producer increments after consumer index is read.
+        // This ensures this method is conservative in it's estimate. Note that as this is an MPMC there is
+        // nothing we can do to make this an exact method.
+        return (lvConsumerIndex() == lvProducerIndex());
+    }
+    
+    @Override
+    public long currentProducerIndex() {
+        return lvProducerIndex();
+    }
+    
+    @Override
+    public long currentConsumerIndex() {
+        return lvConsumerIndex();
+    }
+    
+    protected final long lvProducerIndex() {
+        return producerIndex.get();
+    }
+
+    protected final boolean casProducerIndex(long expect, long newValue) {
+        return producerIndex.compareAndSet(expect, newValue);
+    }
+    protected final long lvConsumerIndex() {
+        return consumerIndex.get();
+    }
+
+    protected final boolean casConsumerIndex(long expect, long newValue) {
+        return consumerIndex.compareAndSet(expect, newValue);
+    }
+
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpscAtomicArrayQueue.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import org.jctools.queues.QueueProgressIndicators;
+
+/**
+ * A Multi-Producer-Single-Consumer queue based on a {@link AtomicReferenceArrayQueue}. This implies that
+ * any thread may call the offer method, but only a single thread may call poll/peek for correctness to
+ * maintained. <br>
+ * This implementation follows patterns documented on the package level for False Sharing protection.<br>
+ * This implementation is using the <a href="http://sourceforge.net/projects/mc-fastflow/">Fast Flow</a>
+ * method for polling from the queue (with minor change to correctly publish the index) and an extension of
+ * the Leslie Lamport concurrent queue algorithm (originated by Martin Thompson) on the producer side.<br>
+ * 
+ * @author nitsanw
+ * 
+ * @param <E>
+ */
+public final class MpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E>
+        implements QueueProgressIndicators {
+    private final AtomicLong consumerIndex;
+    private final AtomicLong producerIndex;
+    private volatile long headCache;
+    public MpscAtomicArrayQueue(int capacity) {
+        super(capacity);
+        this.consumerIndex = new AtomicLong();
+        this.producerIndex = new AtomicLong();
+    }
+    /**
+     * {@inheritDoc} <br>
+     * 
+     * IMPLEMENTATION NOTES:<br>
+     * Lock free offer using a single CAS. As class name suggests access is permitted to many threads
+     * concurrently.
+     * 
+     * @see java.util.Queue#offer(java.lang.Object)
+     * @see MessagePassingQueue#offer(Object)
+     */
+    @Override
+    public boolean offer(final E e) {
+        if (null == e) {
+            throw new NullPointerException("Null is not a valid element");
+        }
+
+        // use a cached view on consumer index (potentially updated in loop)
+        final int mask = this.mask;
+        final long capacity = mask + 1;
+        long consumerIndexCache = lvConsumerIndexCache(); // LoadLoad
+        long currentProducerIndex;
+        do {
+            currentProducerIndex = lvProducerIndex(); // LoadLoad
+            final long wrapPoint = currentProducerIndex - capacity;
+            if (consumerIndexCache <= wrapPoint) {
+                final long currHead = lvConsumerIndex(); // LoadLoad
+                if (currHead <= wrapPoint) {
+                    return false; // FULL :(
+                } else {
+                    // update shared cached value of the consumerIndex
+                    svConsumerIndexCache(currHead); // StoreLoad
+                    // update on stack copy, we might need this value again if we lose the CAS.
+                    consumerIndexCache = currHead;
+                }
+            }
+        } while (!casProducerIndex(currentProducerIndex, currentProducerIndex + 1));
+        /*
+         * NOTE: the new producer index value is made visible BEFORE the element in the array. If we relied on
+         * the index visibility to poll() we would need to handle the case where the element is not visible.
+         */
+
+        // Won CAS, move on to storing
+        final int offset = calcElementOffset(currentProducerIndex, mask);
+        soElement(offset, e); // StoreStore
+        return true; // AWESOME :)
+    }
+
+    /**
+     * A wait free alternative to offer which fails on CAS failure.
+     * 
+     * @param e new element, not null
+     * @return 1 if next element cannot be filled, -1 if CAS failed, 0 if successful
+     */
+    public final int weakOffer(final E e) {
+        if (null == e) {
+            throw new NullPointerException("Null is not a valid element");
+        }
+        final int mask = this.mask;
+        final long capacity = mask + 1;
+        final long currentTail = lvProducerIndex(); // LoadLoad
+        final long consumerIndexCache = lvConsumerIndexCache(); // LoadLoad
+        final long wrapPoint = currentTail - capacity;
+        if (consumerIndexCache <= wrapPoint) {
+            long currHead = lvConsumerIndex(); // LoadLoad
+            if (currHead <= wrapPoint) {
+                return 1; // FULL :(
+            } else {
+                svConsumerIndexCache(currHead); // StoreLoad
+            }
+        }
+
+        // look Ma, no loop!
+        if (!casProducerIndex(currentTail, currentTail + 1)) {
+            return -1; // CAS FAIL :(
+        }
+
+        // Won CAS, move on to storing
+        final int offset = calcElementOffset(currentTail, mask);
+        soElement(offset, e);
+        return 0; // AWESOME :)
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * IMPLEMENTATION NOTES:<br>
+     * Lock free poll using ordered loads/stores. As class name suggests access is limited to a single thread.
+     * 
+     * @see java.util.Queue#poll()
+     * @see MessagePassingQueue#poll()
+     */
+    @Override
+    public E poll() {
+        final long consumerIndex = lvConsumerIndex(); // LoadLoad
+        final int offset = calcElementOffset(consumerIndex);
+        // Copy field to avoid re-reading after volatile load
+        final AtomicReferenceArray<E> buffer = this.buffer;
+
+        // If we can't see the next available element we can't poll
+        E e = lvElement(buffer, offset); // LoadLoad
+        if (null == e) {
+            /*
+             * NOTE: Queue may not actually be empty in the case of a producer (P1) being interrupted after
+             * winning the CAS on offer but before storing the element in the queue. Other producers may go on
+             * to fill up the queue after this element.
+             */
+            if (consumerIndex != lvProducerIndex()) {
+                do {
+                    e = lvElement(buffer, offset);
+                } while (e == null);
+            } else {
+                return null;
+            }
+        }
+
+        spElement(buffer, offset, null);
+        soConsumerIndex(consumerIndex + 1); // StoreStore
+        return e;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * IMPLEMENTATION NOTES:<br>
+     * Lock free peek using ordered loads. As class name suggests access is limited to a single thread.
+     * 
+     * @see java.util.Queue#poll()
+     * @see MessagePassingQueue#poll()
+     */
+    @Override
+    public E peek() {
+        // Copy field to avoid re-reading after volatile load
+        final AtomicReferenceArray<E> buffer = this.buffer;
+
+        final long consumerIndex = lvConsumerIndex(); // LoadLoad
+        final int offset = calcElementOffset(consumerIndex);
+        E e = lvElement(buffer, offset);
+        if (null == e) {
+            /*
+             * NOTE: Queue may not actually be empty in the case of a producer (P1) being interrupted after
+             * winning the CAS on offer but before storing the element in the queue. Other producers may go on
+             * to fill up the queue after this element.
+             */
+            if (consumerIndex != lvProducerIndex()) {
+                do {
+                    e = lvElement(buffer, offset);
+                } while (e == null);
+            } else {
+                return null;
+            }
+        }
+        return e;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * 
+     */
+    @Override
+    public int size() {
+        /*
+         * It is possible for a thread to be interrupted or reschedule between the read of the producer and
+         * consumer indices, therefore protection is required to ensure size is within valid range. In the
+         * event of concurrent polls/offers to this method the size is OVER estimated as we read consumer
+         * index BEFORE the producer index.
+         */
+        long after = lvConsumerIndex();
+        while (true) {
+            final long before = after;
+            final long currentProducerIndex = lvProducerIndex();
+            after = lvConsumerIndex();
+            if (before == after) {
+                return (int) (currentProducerIndex - after);
+            }
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        // Order matters!
+        // Loading consumer before producer allows for producer increments after consumer index is read.
+        // This ensures the correctness of this method at least for the consumer thread. Other threads POV is
+        // not really
+        // something we can fix here.
+        return (lvConsumerIndex() == lvProducerIndex());
+    }
+    
+    @Override
+    public long currentProducerIndex() {
+        return lvProducerIndex();
+    }
+    
+    @Override
+    public long currentConsumerIndex() {
+        return lvConsumerIndex();
+    }
+    private long lvConsumerIndex() {
+        return consumerIndex.get();
+    }
+    private long lvProducerIndex() {
+        return producerIndex.get();
+    }
+    protected final long lvConsumerIndexCache() {
+        return headCache;
+    }
+
+    protected final void svConsumerIndexCache(long v) {
+        headCache = v;
+    }
+    protected final boolean casProducerIndex(long expect, long newValue) {
+        return producerIndex.compareAndSet(expect, newValue);
+    }
+    protected void soConsumerIndex(long l) {
+        consumerIndex.lazySet(l);
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpscLinkedAtomicQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpscLinkedAtomicQueue.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+/**
+ * This is a direct Java port of the MPSC algorithm as presented <a
+ * href="http://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue"> on 1024
+ * Cores</a> by D. Vyukov. The original has been adapted to Java and it's quirks with regards to memory model and
+ * layout:
+ * <ol>
+ * <li>Use XCHG functionality provided by AtomicReference (which is better in JDK 8+).
+ * </ol>
+ * The queue is initialized with a stub node which is set to both the producer and consumer node references. From this
+ * point follow the notes on offer/poll.
+ * 
+ * @author nitsanw
+ * 
+ * @param <E>
+ */
+public final class MpscLinkedAtomicQueue<E> extends BaseLinkedAtomicQueue<E> {
+
+    public MpscLinkedAtomicQueue() {
+        super();
+        LinkedQueueAtomicNode<E> node = new LinkedQueueAtomicNode<E>();
+        spConsumerNode(node);
+        xchgProducerNode(node);// this ensures correct construction: StoreLoad
+    }
+    /**
+     * {@inheritDoc} <br>
+     * <p>
+     * IMPLEMENTATION NOTES:<br>
+     * Offer is allowed from multiple threads.<br>
+     * Offer allocates a new node and:
+     * <ol>
+     * <li>Swaps it atomically with current producer node (only one producer 'wins')
+     * <li>Sets the new node as the node following from the swapped producer node
+     * </ol>
+     * This works because each producer is guaranteed to 'plant' a new node and link the old node. No 2 producers can
+     * get the same producer node as part of XCHG guarantee.
+     * 
+     * @see MessagePassingQueue#offer(Object)
+     * @see java.util.Queue#offer(java.lang.Object)
+     */
+    @Override
+    public final boolean offer(final E nextValue) {
+        if (nextValue == null) {
+            throw new IllegalArgumentException("null elements not allowed");
+        }
+        final LinkedQueueAtomicNode<E> nextNode = new LinkedQueueAtomicNode<E>(nextValue);
+        final LinkedQueueAtomicNode<E> prevProducerNode = xchgProducerNode(nextNode);
+        // Should a producer thread get interrupted here the chain WILL be broken until that thread is resumed
+        // and completes the store in prev.next.
+        prevProducerNode.soNext(nextNode); // StoreStore
+        return true;
+    }
+
+    /**
+     * {@inheritDoc} <br>
+     * <p>
+     * IMPLEMENTATION NOTES:<br>
+     * Poll is allowed from a SINGLE thread.<br>
+     * Poll reads the next node from the consumerNode and:
+     * <ol>
+     * <li>If it is null, the queue is assumed empty (though it might not be).
+     * <li>If it is not null set it as the consumer node and return it's now evacuated value.
+     * </ol>
+     * This means the consumerNode.value is always null, which is also the starting point for the queue. Because null
+     * values are not allowed to be offered this is the only node with it's value set to null at any one time.
+     * 
+     * @see MessagePassingQueue#poll()
+     * @see java.util.Queue#poll()
+     */
+    @Override
+    public final E poll() {
+        LinkedQueueAtomicNode<E> currConsumerNode = lpConsumerNode(); // don't load twice, it's alright
+        LinkedQueueAtomicNode<E> nextNode = currConsumerNode.lvNext();
+        if (nextNode != null) {
+            // we have to null out the value because we are going to hang on to the node
+            final E nextValue = nextNode.getAndNullValue();
+            spConsumerNode(nextNode);
+            return nextValue;
+        }
+        else if (currConsumerNode != lvProducerNode()) {
+            // spin, we are no longer wait free
+            while((nextNode = currConsumerNode.lvNext()) == null);
+            // got the next node...
+            
+            // we have to null out the value because we are going to hang on to the node
+            final E nextValue = nextNode.getAndNullValue();
+            spConsumerNode(nextNode);
+            return nextValue;
+        }
+        return null;
+    }
+
+    @Override
+    public final E peek() {
+        LinkedQueueAtomicNode<E> currConsumerNode = lpConsumerNode(); // don't load twice, it's alright
+        LinkedQueueAtomicNode<E> nextNode = currConsumerNode.lvNext();
+        if (nextNode != null) {
+            return nextNode.lpValue();
+        }
+        else if (currConsumerNode != lvProducerNode()) {
+            // spin, we are no longer wait free
+            while((nextNode = currConsumerNode.lvNext()) == null);
+            // got the next node...
+            return nextNode.lpValue();
+        }
+        return null;
+    }
+
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SequencedAtomicReferenceArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SequencedAtomicReferenceArrayQueue.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import java.util.concurrent.atomic.AtomicLongArray;
+
+abstract class SequencedAtomicReferenceArrayQueue<E> extends
+        AtomicReferenceArrayQueue<E> {
+    protected final AtomicLongArray sequenceBuffer;
+    public SequencedAtomicReferenceArrayQueue(int capacity) {
+        super(capacity);
+        int actualCapacity = this.mask + 1;
+        // pad data on either end with some empty slots.
+        sequenceBuffer = new AtomicLongArray(actualCapacity);
+        for (int i = 0; i < actualCapacity; i++) {
+            soSequence(sequenceBuffer, i, i);
+        }
+    }
+
+    protected final long calcSequenceOffset(long index) {
+        return calcSequenceOffset(index, mask);
+    }
+    protected static final int calcSequenceOffset(long index, int mask) {
+        return (int)index & mask;
+    }
+    protected final void soSequence(AtomicLongArray buffer, int offset, long e) {
+        buffer.lazySet(offset, e);
+    }
+
+    protected final long lvSequence(AtomicLongArray buffer, int offset) {
+        return buffer.get(offset);
+    }
+
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import org.jctools.queues.QueueProgressIndicators;
+
+/**
+ * A single-producer multiple-consumer AtomicReferenceArray-backed queue.
+ * @author akarnokd
+ * @param <E>
+ */
+public final class SpmcAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E> implements QueueProgressIndicators{
+    private final AtomicLong consumerIndex;
+    private final AtomicLong producerIndex;
+    private final AtomicLong producerIndexCache;
+    public SpmcAtomicArrayQueue(int capacity) {
+        super(capacity);
+        this.consumerIndex = new AtomicLong();
+        this.producerIndex = new AtomicLong();
+        this.producerIndexCache = new AtomicLong();
+    }
+    @Override
+    public boolean offer(final E e) {
+        if (null == e) {
+            throw new NullPointerException("Null is not a valid element");
+        }
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final int mask = this.mask;
+        final long currProducerIndex = lvProducerIndex();
+        final int offset = calcElementOffset(currProducerIndex, mask);
+        if (null != lvElement(buffer, offset)) {
+            long size = currProducerIndex - lvConsumerIndex();
+            
+            if(size > mask) {
+                return false;
+            }
+            else {
+                // spin wait for slot to clear, buggers wait freedom
+                while(null != lvElement(buffer, offset));
+            }
+        }
+        spElement(buffer, offset, e);
+        // single producer, so store ordered is valid. It is also required to correctly publish the element
+        // and for the consumers to pick up the tail value.
+        soTail(currProducerIndex + 1);
+        return true;
+    }
+
+    @Override
+    public E poll() {
+        long currentConsumerIndex;
+        final long currProducerIndexCache = lvProducerIndexCache();
+        do {
+            currentConsumerIndex = lvConsumerIndex();
+            if (currentConsumerIndex >= currProducerIndexCache) {
+                long currProducerIndex = lvProducerIndex();
+                if (currentConsumerIndex >= currProducerIndex) {
+                    return null;
+                } else {
+                    svProducerIndexCache(currProducerIndex);
+                }
+            }
+        } while (!casHead(currentConsumerIndex, currentConsumerIndex + 1));
+        // consumers are gated on latest visible tail, and so can't see a null value in the queue or overtake
+        // and wrap to hit same location.
+        final int offset = calcElementOffset(currentConsumerIndex);
+        final AtomicReferenceArray<E> lb = buffer;
+        // load plain, element happens before it's index becomes visible
+        final E e = lpElement(lb, offset);
+        // store ordered, make sure nulling out is visible. Producer is waiting for this value.
+        soElement(lb, offset, null);
+        return e;
+    }
+
+    @Override
+    public E peek() {
+        final int mask = this.mask;
+        final long currProducerIndexCache = lvProducerIndexCache();
+        long currentConsumerIndex;
+        E e;
+        do {
+            currentConsumerIndex = lvConsumerIndex();
+            if (currentConsumerIndex >= currProducerIndexCache) {
+                long currProducerIndex = lvProducerIndex();
+                if (currentConsumerIndex >= currProducerIndex) {
+                    return null;
+                } else {
+                    svProducerIndexCache(currProducerIndex);
+                }
+            }
+        } while (null == (e = lvElement(calcElementOffset(currentConsumerIndex, mask))));
+        return e;
+    }
+
+    @Override
+    public int size() {
+        /*
+         * It is possible for a thread to be interrupted or reschedule between the read of the producer and consumer
+         * indices, therefore protection is required to ensure size is within valid range. In the event of concurrent
+         * polls/offers to this method the size is OVER estimated as we read consumer index BEFORE the producer index.
+         */
+        long after = lvConsumerIndex();
+        while (true) {
+            final long before = after;
+            final long currentProducerIndex = lvProducerIndex();
+            after = lvConsumerIndex();
+            if (before == after) {
+                return (int) (currentProducerIndex - after);
+            }
+        }
+    }
+    
+    @Override
+    public boolean isEmpty() {
+        // Order matters! 
+        // Loading consumer before producer allows for producer increments after consumer index is read.
+        // This ensures the correctness of this method at least for the consumer thread. Other threads POV is not really
+        // something we can fix here.
+        return (lvConsumerIndex() == lvProducerIndex());
+    }
+    
+    @Override
+    public long currentProducerIndex() {
+        return lvProducerIndex();
+    }
+    
+    @Override
+    public long currentConsumerIndex() {
+        return lvConsumerIndex();
+    }
+    protected final long lvProducerIndexCache() {
+        return producerIndexCache.get();
+    }
+
+    protected final void svProducerIndexCache(long v) {
+        producerIndexCache.set(v);
+    }
+    protected final long lvConsumerIndex() {
+        return consumerIndex.get();
+    }
+
+    protected final boolean casHead(long expect, long newValue) {
+        return consumerIndex.compareAndSet(expect, newValue);
+    }
+
+    protected final long lvProducerIndex() {
+        return producerIndex.get();
+    }
+
+    protected final void soTail(long v) {
+        producerIndex.lazySet(v);
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import org.jctools.queues.QueueProgressIndicators;
+
+/**
+ * A Single-Producer-Single-Consumer queue backed by a pre-allocated buffer.
+ * <p>
+ * This implementation is a mashup of the <a href="http://sourceforge.net/projects/mc-fastflow/">Fast Flow</a>
+ * algorithm with an optimization of the offer method taken from the <a
+ * href="http://staff.ustc.edu.cn/~bhua/publications/IJPP_draft.pdf">BQueue</a> algorithm (a variation on Fast
+ * Flow), and adjusted to comply with Queue.offer semantics with regards to capacity.<br>
+ * For convenience the relevant papers are available in the resources folder:<br>
+ * <i>2010 - Pisa - SPSC Queues on Shared Cache Multi-Core Systems.pdf<br>
+ * 2012 - Junchang- BQueue- Efﬁcient and Practical Queuing.pdf <br>
+ * </i> This implementation is wait free.
+ * 
+ * @author akarnokd
+ * 
+ * @param <E>
+ */
+public final class SpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E> implements QueueProgressIndicators {
+    private static final Integer MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
+    final AtomicLong producerIndex;
+    protected long producerLookAhead;
+    final AtomicLong consumerIndex;
+    final int lookAheadStep;
+    public SpscAtomicArrayQueue(int capacity) {
+        super(capacity);
+        this.producerIndex = new AtomicLong();
+        this.consumerIndex = new AtomicLong();
+        lookAheadStep = Math.min(capacity / 4, MAX_LOOK_AHEAD_STEP);
+    }
+
+    @Override
+    public boolean offer(E e) {
+        if (null == e) {
+            throw new NullPointerException("Null is not a valid element");
+        }
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final int mask = this.mask;
+        final long index = producerIndex.get();
+        final int offset = calcElementOffset(index, mask);
+        if (index >= producerLookAhead) {
+            int step = lookAheadStep;
+            if (null == lvElement(buffer, calcElementOffset(index + step, mask))) {// LoadLoad
+                producerLookAhead = index + step;
+            }
+            else if (null != lvElement(buffer, offset)){
+                return false;
+            }
+        }
+        soProducerIndex(index + 1); // ordered store -> atomic and ordered for size()
+        soElement(buffer, offset, e); // StoreStore
+        return true;
+    }
+
+    @Override
+    public E poll() {
+        final long index = consumerIndex.get();
+        final int offset = calcElementOffset(index);
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<E> lElementBuffer = buffer;
+        final E e = lvElement(lElementBuffer, offset);// LoadLoad
+        if (null == e) {
+            return null;
+        }
+        soConsumerIndex(index + 1); // ordered store -> atomic and ordered for size()
+        soElement(lElementBuffer, offset, null);// StoreStore
+        return e;
+    }
+
+    @Override
+    public E peek() {
+        return lvElement(calcElementOffset(consumerIndex.get()));
+    }
+
+    @Override
+    public int size() {
+        /*
+         * It is possible for a thread to be interrupted or reschedule between the read of the producer and consumer
+         * indices, therefore protection is required to ensure size is within valid range. In the event of concurrent
+         * polls/offers to this method the size is OVER estimated as we read consumer index BEFORE the producer index.
+         */
+        long after = lvConsumerIndex();
+        while (true) {
+            final long before = after;
+            final long currentProducerIndex = lvProducerIndex();
+            after = lvConsumerIndex();
+            if (before == after) {
+                return (int) (currentProducerIndex - after);
+            }
+        }
+    }
+    @Override
+    public long currentProducerIndex() {
+        return lvProducerIndex();
+    }
+    
+    @Override
+    public long currentConsumerIndex() {
+        return lvConsumerIndex();
+    }
+
+    private void soProducerIndex(long newIndex) {
+        producerIndex.lazySet(newIndex);
+    }
+
+    private void soConsumerIndex(long newIndex) {
+        consumerIndex.lazySet(newIndex);
+    }
+    
+    private long lvConsumerIndex() {
+        return consumerIndex.get();
+    }
+    private long lvProducerIndex() {
+        return producerIndex.get();
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscLinkedAtomicQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscLinkedAtomicQueue.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+/**
+ * This is a weakened version of the MPSC algorithm as presented <a
+ * href="http://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue"> on 1024
+ * Cores</a> by D. Vyukov. The original has been adapted to Java and it's quirks with regards to memory model and
+ * layout:
+ * <ol>
+ * <li>As this is an SPSC we have no need for XCHG, an ordered store is enough.
+ * </ol>
+ * The queue is initialized with a stub node which is set to both the producer and consumer node references. From this
+ * point follow the notes on offer/poll.
+ * 
+ * @author nitsanw
+ * 
+ * @param <E>
+ */
+public final class SpscLinkedAtomicQueue<E> extends BaseLinkedAtomicQueue<E> {
+
+    public SpscLinkedAtomicQueue() {
+        super();
+        LinkedQueueAtomicNode<E> node = new LinkedQueueAtomicNode<E>();
+        spProducerNode(node);
+        spConsumerNode(node);
+        node.soNext(null); // this ensures correct construction: StoreStore
+    }
+
+    /**
+     * {@inheritDoc} <br>
+     * 
+     * IMPLEMENTATION NOTES:<br>
+     * Offer is allowed from a SINGLE thread.<br>
+     * Offer allocates a new node (holding the offered value) and:
+     * <ol>
+     * <li>Sets that node as the producerNode.next
+     * <li>Sets the new node as the producerNode
+     * </ol>
+     * From this follows that producerNode.next is always null and for all other nodes node.next is not null.
+     * 
+     * @see MessagePassingQueue#offer(Object)
+     * @see java.util.Queue#offer(java.lang.Object)
+     */
+    @Override
+    public boolean offer(final E nextValue) {
+        if (nextValue == null) {
+            throw new IllegalArgumentException("null elements not allowed");
+        }
+        final LinkedQueueAtomicNode<E> nextNode = new LinkedQueueAtomicNode<E>(nextValue);
+        lpProducerNode().soNext(nextNode);
+        spProducerNode(nextNode);
+        return true;
+    }
+
+    /**
+     * {@inheritDoc} <br>
+     * 
+     * IMPLEMENTATION NOTES:<br>
+     * Poll is allowed from a SINGLE thread.<br>
+     * Poll reads the next node from the consumerNode and:
+     * <ol>
+     * <li>If it is null, the queue is empty.
+     * <li>If it is not null set it as the consumer node and return it's now evacuated value.
+     * </ol>
+     * This means the consumerNode.value is always null, which is also the starting point for the queue. Because null
+     * values are not allowed to be offered this is the only node with it's value set to null at any one time.
+     * 
+     */
+    @Override
+    public E poll() {
+        final LinkedQueueAtomicNode<E> nextNode = lpConsumerNode().lvNext();
+        if (nextNode != null) {
+            // we have to null out the value because we are going to hang on to the node
+            final E nextValue = nextNode.getAndNullValue();
+            spConsumerNode(nextNode);
+            return nextValue;
+        }
+        return null;
+    }
+
+    @Override
+    public E peek() {
+        final LinkedQueueAtomicNode<E> nextNode = lpConsumerNode().lvNext();
+        if (nextNode != null) {
+            return nextNode.lpValue();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscUnboundedAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscUnboundedAtomicArrayQueue.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import org.jctools.queues.QueueProgressIndicators;
+import org.jctools.util.Pow2;
+
+public class SpscUnboundedAtomicArrayQueue<E> extends AbstractQueue<E> implements QueueProgressIndicators{
+    static final int MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
+    protected final AtomicLong producerIndex;
+    protected int producerLookAheadStep;
+    protected long producerLookAhead;
+    protected int producerMask;
+    protected AtomicReferenceArray<Object> producerBuffer;
+    protected int consumerMask;
+    protected AtomicReferenceArray<Object> consumerBuffer;
+    protected final AtomicLong consumerIndex;
+    private static final Object HAS_NEXT = new Object();
+
+    public SpscUnboundedAtomicArrayQueue(final int bufferSize) {
+        int p2capacity = Pow2.roundToPowerOfTwo(bufferSize);
+        int mask = p2capacity - 1;
+        AtomicReferenceArray<Object> buffer = new AtomicReferenceArray<Object>(p2capacity + 1);
+        producerBuffer = buffer;
+        producerMask = mask;
+        adjustLookAheadStep(p2capacity);
+        consumerBuffer = buffer;
+        consumerMask = mask;
+        producerLookAhead = mask - 1; // we know it's all empty to start with
+        producerIndex = new AtomicLong();
+        consumerIndex = new AtomicLong();
+        soProducerIndex(0L);
+    }
+
+    @Override
+    public final Iterator<E> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single producer thread use only.
+     */
+    @Override
+    public final boolean offer(final E e) {
+        if (null == e) {
+            throw new NullPointerException("Null is not a valid element");
+        }
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<Object> buffer = producerBuffer;
+        final long index = lpProducerIndex();
+        final int mask = producerMask;
+        final int offset = calcWrappedOffset(index, mask);
+        if (index < producerLookAhead) {
+            return writeToQueue(buffer, e, index, offset);
+        } else {
+            final int lookAheadStep = producerLookAheadStep;
+            // go around the buffer or resize if full (unless we hit max capacity)
+            int lookAheadElementOffset = calcWrappedOffset(index + lookAheadStep, mask);
+            if (null == lvElement(buffer, lookAheadElementOffset)) {// LoadLoad
+                producerLookAhead = index + lookAheadStep - 1; // joy, there's plenty of room
+                return writeToQueue(buffer, e, index, offset);
+            } else if (null != lvElement(buffer, calcWrappedOffset(index + 1, mask))) { // buffer is not full
+                return writeToQueue(buffer, e, index, offset);
+            } else {
+                resize(buffer, index, offset, e, mask); // add a buffer and link old to new
+                return true;
+            }
+        }
+    }
+
+    private boolean writeToQueue(final AtomicReferenceArray<Object> buffer, final E e, final long index, final int offset) {
+        soProducerIndex(index + 1);// this ensures atomic write of long on 32bit platforms
+        soElement(buffer, offset, e);// StoreStore
+        return true;
+    }
+
+    private void resize(final AtomicReferenceArray<Object> oldBuffer, final long currIndex, final int offset, final E e,
+            final long mask) {
+        final int capacity = oldBuffer.length();
+        final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<Object>(capacity);
+        producerBuffer = newBuffer;
+        producerLookAhead = currIndex + mask - 1;
+        soProducerIndex(currIndex + 1);// this ensures correctness on 32bit platforms
+        soElement(newBuffer, offset, e);// StoreStore
+        soNext(oldBuffer, newBuffer);
+        soElement(oldBuffer, offset, HAS_NEXT); // new buffer is visible after element is
+                                                                 // inserted
+    }
+
+    private void soNext(AtomicReferenceArray<Object> curr, AtomicReferenceArray<Object> next) {
+        soElement(curr, calcDirectOffset(curr.length() - 1), next);
+    }
+    @SuppressWarnings("unchecked")
+    private AtomicReferenceArray<Object> lvNext(AtomicReferenceArray<Object> curr) {
+        return (AtomicReferenceArray<Object>)lvElement(curr, calcDirectOffset(curr.length() - 1));
+    }
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single consumer thread use only.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public final E poll() {
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<Object> buffer = consumerBuffer;
+        final long index = lpConsumerIndex();
+        final int mask = consumerMask;
+        final int offset = calcWrappedOffset(index, mask);
+        final Object e = lvElement(buffer, offset);// LoadLoad
+        boolean isNextBuffer = e == HAS_NEXT;
+        if (null != e && !isNextBuffer) {
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
+            soElement(buffer, offset, null);// StoreStore
+            return (E) e;
+        } else if (isNextBuffer) {
+            return newBufferPoll(lvNext(buffer), index, mask);
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private E newBufferPoll(AtomicReferenceArray<Object> nextBuffer, final long index, final int mask) {
+        consumerBuffer = nextBuffer;
+        final int offsetInNew = calcWrappedOffset(index, mask);
+        final E n = (E) lvElement(nextBuffer, offsetInNew);// LoadLoad
+        if (null == n) {
+            return null;
+        } else {
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
+            soElement(nextBuffer, offsetInNew, null);// StoreStore
+            return n;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single consumer thread use only.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public final E peek() {
+        final AtomicReferenceArray<Object> buffer = consumerBuffer;
+        final long index = lpConsumerIndex();
+        final int mask = consumerMask;
+        final int offset = calcWrappedOffset(index, mask);
+        final Object e = lvElement(buffer, offset);// LoadLoad
+        if (e == HAS_NEXT) {
+            return newBufferPeek(lvNext(buffer), index, mask);
+        }
+
+        return (E) e;
+    }
+
+    @SuppressWarnings("unchecked")
+    private E newBufferPeek(AtomicReferenceArray<Object> nextBuffer, final long index, final int mask) {
+        consumerBuffer = nextBuffer;
+        final int offsetInNew = calcWrappedOffset(index, mask);
+        return (E) lvElement(nextBuffer, offsetInNew);// LoadLoad
+    }
+
+    @Override
+    public final int size() {
+        /*
+         * It is possible for a thread to be interrupted or reschedule between the read of the producer and
+         * consumer indices, therefore protection is required to ensure size is within valid range. In the
+         * event of concurrent polls/offers to this method the size is OVER estimated as we read consumer
+         * index BEFORE the producer index.
+         */
+        long after = lvConsumerIndex();
+        while (true) {
+            final long before = after;
+            final long currentProducerIndex = lvProducerIndex();
+            after = lvConsumerIndex();
+            if (before == after) {
+                return (int) (currentProducerIndex - after);
+            }
+        }
+    }
+
+    private void adjustLookAheadStep(int capacity) {
+        producerLookAheadStep = Math.min(capacity / 4, MAX_LOOK_AHEAD_STEP);
+    }
+
+    private long lvProducerIndex() {
+        return producerIndex.get();
+    }
+
+    private long lvConsumerIndex() {
+        return consumerIndex.get();
+    }
+
+    private long lpProducerIndex() {
+        return producerIndex.get();
+    }
+
+    private long lpConsumerIndex() {
+        return consumerIndex.get();
+    }
+
+    private void soProducerIndex(long v) {
+        producerIndex.lazySet(v);
+    }
+
+    private void soConsumerIndex(long v) {
+        consumerIndex.lazySet(v);
+    }
+
+    private static final int calcWrappedOffset(long index, int mask) {
+        return calcDirectOffset((int)index & mask);
+    }
+    private static final int calcDirectOffset(int index) {
+        return index;
+    }
+    private static final void soElement(AtomicReferenceArray<Object> buffer, int offset, Object e) {
+        buffer.lazySet(offset, e);
+    }
+
+    private static final <E> Object lvElement(AtomicReferenceArray<Object> buffer, int offset) {
+        return buffer.get(offset);
+    }
+    
+    @Override
+    public long currentProducerIndex() {
+        return lvProducerIndex();
+    }
+    
+    @Override
+    public long currentConsumerIndex() {
+        return lvConsumerIndex();
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicQueueSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicQueueSanityTest.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import static org.hamcrest.Matchers.*;
+import static org.jctools.queues.matchers.Matchers.emptyAndZeroSize;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeThat;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jctools.queues.spec.ConcurrentQueueSpec;
+import org.jctools.queues.spec.Ordering;
+import org.jctools.queues.spec.Preference;
+import org.jctools.util.Pow2;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class AtomicQueueSanityTest {
+
+    private static final int SIZE = 8192 * 2;
+    @Parameterized.Parameters
+    public static Collection<?> parameters() {
+        ArrayList<Object[]> list = new ArrayList<Object[]>();
+        list.add(test(1, 1, 1, Ordering.FIFO, null));
+        list.add(test(1, 1, 0, Ordering.FIFO, null));
+        list.add(test(1, 1, SIZE, Ordering.FIFO, null));
+//        list.add(test(1, 1, 16, Ordering.FIFO, new SpscGrowableArrayQueue<Integer>(4, 16)));
+        list.add(test(1, 1, 0, Ordering.FIFO, new SpscUnboundedAtomicArrayQueue<Integer>(16)));
+        list.add(test(1, 0, 1, Ordering.FIFO, null));
+        list.add(test(1, 0, SIZE, Ordering.FIFO, null));
+        list.add(test(0, 1, 0, Ordering.FIFO, null));
+        list.add(test(0, 1, 1, Ordering.FIFO, null));
+        list.add(test(0, 1, SIZE, Ordering.FIFO, null));
+        list.add(test(0, 1, 1, Ordering.PRODUCER_FIFO, null));
+        list.add(test(0, 1, SIZE, Ordering.PRODUCER_FIFO, null));
+        // Compound queue minimal size is the core count
+        list.add(test(0, 1, Runtime.getRuntime().availableProcessors(), Ordering.NONE, null));
+        list.add(test(0, 1, SIZE, Ordering.NONE, null));
+        // Mpmc minimal size is 2
+        list.add(test(0, 0, 2, Ordering.FIFO, null));
+        list.add(test(0, 0, SIZE, Ordering.FIFO, null));
+        return list;
+    }
+
+    private final Queue<Integer> queue;
+    private final ConcurrentQueueSpec spec;
+
+    public AtomicQueueSanityTest(ConcurrentQueueSpec spec, Queue<Integer> queue) {
+        this.queue = queue;
+        this.spec = spec;
+    }
+
+    @Before
+    public void clear() {
+        queue.clear();
+    }
+
+    @Test
+    public void sanity() {
+        for (int i = 0; i < SIZE; i++) {
+            assertNull(queue.poll());
+            assertThat(queue, emptyAndZeroSize());
+        }
+        int i = 0;
+        while (i < SIZE && queue.offer(i))
+            i++;
+        int size = i;
+        assertEquals(size, queue.size());
+        if (spec.ordering == Ordering.FIFO) {
+            // expect FIFO
+            i = 0;
+            Integer p;
+            Integer e;
+            while ((p = queue.peek()) != null) {
+                e = queue.poll();
+                assertEquals(p, e);
+                assertEquals(size - (i + 1), queue.size());
+                assertEquals(i++, e.intValue());
+            }
+            assertEquals(size, i);
+        } else {
+            // expect sum of elements is (size - 1) * size / 2 = 0 + 1 + .... + (size - 1)
+            int sum = (size - 1) * size / 2;
+            i = 0;
+            Integer e;
+            while ((e = queue.poll()) != null) {
+                assertEquals(--size, queue.size());
+                sum -= e.intValue();
+            }
+            assertEquals(0, sum);
+        }
+    }
+
+    @Test
+    public void testSizeIsTheNumberOfOffers() {
+        int currentSize = 0;
+        while (currentSize < SIZE && queue.offer(currentSize)) {
+            currentSize++;
+            assertThat(queue, hasSize(currentSize));
+        }
+    }
+
+    @Test
+    public void whenFirstInThenFirstOut() {
+        assumeThat(spec.ordering, is(Ordering.FIFO));
+
+        // Arrange
+        int i = 0;
+        while (i < SIZE && queue.offer(i)) {
+            i++;
+        }
+        final int size = queue.size();
+
+        // Act
+        i = 0;
+        Integer prev;
+        while ((prev = queue.peek()) != null) {
+            final Integer item = queue.poll();
+
+            assertThat(item, is(prev));
+            assertThat(queue, hasSize(size - (i + 1)));
+            assertThat(item, is(i));
+            i++;
+        }
+
+        // Assert
+        assertThat(i, is(size));
+    }
+
+    @Test
+    public void test_FIFO_PRODUCER_Ordering() throws Exception {
+        assumeThat(spec.ordering, is(not((Ordering.FIFO))));
+
+        // Arrange
+        int i = 0;
+        while (i < SIZE && queue.offer(i)) {
+            i++;
+        }
+        int size = queue.size();
+
+        // Act
+        // expect sum of elements is (size - 1) * size / 2 = 0 + 1 + .... + (size - 1)
+        int sum = (size - 1) * size / 2;
+        Integer e;
+        while ((e = queue.poll()) != null) {
+            size--;
+            assertThat(queue, hasSize(size));
+            sum -= e;
+        }
+
+        // Assert
+        assertThat(sum, is(0));
+    }
+
+    @Test
+    public void whenOfferItemAndPollItemThenSameInstanceReturnedAndQueueIsEmpty() {
+        assertThat(queue, emptyAndZeroSize());
+
+        // Act
+        final Integer e = 1;
+        queue.offer(e);
+        assertThat(queue, not(emptyAndZeroSize()));
+        assertThat(queue, hasSize(1));
+
+        final Integer oh = queue.poll();
+
+        // Assert
+        assertThat(oh, sameInstance(e));
+        assertThat(queue, emptyAndZeroSize());
+    }
+
+    @Test
+    public void testPowerOf2Capacity() {
+        assumeThat(spec.isBounded(), is(true));
+        int n = Pow2.roundToPowerOfTwo(spec.capacity);
+
+        for (int i = 0; i < n; i++) {
+            assertTrue("Failed to insert:"+i,queue.offer(i));
+        }
+        assertFalse(queue.offer(n));
+    }
+
+    static final class Val {
+        public int value;
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testHappensBefore() throws Exception {
+        final AtomicBoolean stop = new AtomicBoolean();
+        final Queue q = queue;
+        final Val fail = new Val();
+        Thread t1 = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while (!stop.get()) {
+                    for (int i = 1; i <= 10; i++) {
+                        Val v = new Val();
+                        v.value = i;
+                        q.offer(v);
+                    }
+                }
+            }
+        });
+        Thread t2 = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while (!stop.get()) {
+                    for (int i = 0; i < 10; i++) {
+                        Val v = (Val) q.peek();
+                        if (v != null && v.value == 0) {
+                            fail.value = 1;
+                            stop.set(true);
+                        }
+                        q.poll();
+                    }
+                }
+            }
+        });
+
+        t1.start();
+        t2.start();
+        Thread.sleep(1000);
+        stop.set(true);
+        t1.join();
+        t2.join();
+        assertEquals("reordering detected", 0, fail.value);
+
+    }
+
+    private static Object[] test(int producers, int consumers, int capacity, Ordering ordering, Queue<Integer> q) {
+        ConcurrentQueueSpec spec = new ConcurrentQueueSpec(producers, consumers, capacity, ordering,
+                Preference.NONE);
+        if(q == null) {
+            q = AtomicQueueFactory.newQueue(spec);
+        }
+        return new Object[] { spec, q };
+    }
+
+}

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscArrayQueueTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscArrayQueueTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.jctools.queues.matchers.Matchers.emptyAndZeroSize;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class AtomicSpscArrayQueueTest {
+    @Test
+    public void shouldWorkAfterWrap(){
+        // Arrange
+        final SpscAtomicArrayQueue<Object> q = new SpscAtomicArrayQueue<Object>(1024);
+        // starting point for empty queue at max long, next offer will wrap the producerIndex
+        q.consumerIndex.set(Long.MAX_VALUE);
+        q.producerIndex.set(Long.MAX_VALUE);
+        q.producerLookAhead = Long.MAX_VALUE;
+        // valid starting point
+        assertThat(q, emptyAndZeroSize());
+
+        // Act
+        // assert offer is successful
+        final Object e = new Object();
+        assertTrue(q.offer(e));
+        // size is computed correctly after wrap
+        assertThat(q, not(emptyAndZeroSize()));
+        assertThat(q, hasSize(1));
+        
+        // now consumer index wraps
+        final Object poll = q.poll();
+        assertThat(poll, sameInstance(e));
+        assertThat(q, emptyAndZeroSize());
+        
+        // let's go again
+        assertTrue(q.offer(e));
+        assertThat(q, not(emptyAndZeroSize()));
+
+        final Object poll2 = q.poll();
+        assertThat(poll2, sameInstance(e));
+        assertThat(q, emptyAndZeroSize());
+    }
+}


### PR DESCRIPTION
I've converted most queue implementations. I've omitted class padding and array index scaling to save on memory for limited systems (such as Android).