### PR TITLE
unsafe methods as static-final

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/ConcurrentCircularArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/ConcurrentCircularArrayQueue.java
@@ -38,9 +38,9 @@ abstract class ConcurrentCircularArrayQueueL0Pad<E> extends AbstractQueue<E> imp
  * Load/Store methods using a <i>buffer</i> parameter are provided to allow the prevention of final field reload after a
  * LoadLoad barrier.
  * <p>
- * 
+ *
  * @author nitsanw
- * 
+ *
  * @param <E>
  */
 public abstract class ConcurrentCircularArrayQueue<E> extends ConcurrentCircularArrayQueueL0Pad<E> {
@@ -83,7 +83,7 @@ public abstract class ConcurrentCircularArrayQueue<E> extends ConcurrentCircular
     }
     /**
      * @param index desirable element index
-     * @param mask 
+     * @param mask
      * @return the offset in bytes within the array for a given index.
      */
     protected static final long calcElementOffset(long index, long mask) {
@@ -91,7 +91,7 @@ public abstract class ConcurrentCircularArrayQueue<E> extends ConcurrentCircular
     }
     /**
      * A plain store (no ordering/fences) of an element to a given offset
-     * 
+     *
      * @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
      * @param e a kitty
      */
@@ -101,18 +101,18 @@ public abstract class ConcurrentCircularArrayQueue<E> extends ConcurrentCircular
 
     /**
      * A plain store (no ordering/fences) of an element to a given offset
-     * 
+     *
      * @param buffer this.buffer
      * @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
      * @param e an orderly kitty
      */
-    protected final void spElement(E[] buffer, long offset, E e) {
+    protected static final void spElement(Object[] buffer, long offset, Object e) {
         UNSAFE.putObject(buffer, offset, e);
     }
 
     /**
      * An ordered store(store + StoreStore barrier) of an element to a given offset
-     * 
+     *
      * @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
      * @param e an orderly kitty
      */
@@ -122,57 +122,57 @@ public abstract class ConcurrentCircularArrayQueue<E> extends ConcurrentCircular
 
     /**
      * An ordered store(store + StoreStore barrier) of an element to a given offset
-     * 
+     *
      * @param buffer this.buffer
      * @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
      * @param e an orderly kitty
      */
-    protected final void soElement(E[] buffer, long offset, E e) {
+    protected static final void soElement(Object[] buffer, long offset, Object e) {
         UNSAFE.putOrderedObject(buffer, offset, e);
     }
 
     /**
      * A plain load (no ordering/fences) of an element from a given offset.
-     * 
+     *
      * @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
      * @return the element at the offset
      */
+    @SuppressWarnings("unchecked")
     protected final E lpElement(long offset) {
-        return lpElement(buffer, offset);
+        return (E) lpElement(buffer, offset);
     }
 
     /**
      * A plain load (no ordering/fences) of an element from a given offset.
-     * 
+     *
      * @param buffer this.buffer
      * @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
      * @return the element at the offset
      */
-    @SuppressWarnings("unchecked")
-    protected final E lpElement(E[] buffer, long offset) {
-        return (E) UNSAFE.getObject(buffer, offset);
+    protected static final Object lpElement(Object[] buffer, long offset) {
+        return UNSAFE.getObject(buffer, offset);
     }
 
     /**
      * A volatile load (load + LoadLoad barrier) of an element from a given offset.
-     * 
+     *
      * @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
      * @return the element at the offset
      */
+    @SuppressWarnings("unchecked")
     protected final E lvElement(long offset) {
-        return lvElement(buffer, offset);
+        return (E) lvElement(buffer, offset);
     }
 
     /**
      * A volatile load (load + LoadLoad barrier) of an element from a given offset.
-     * 
+     *
      * @param buffer this.buffer
      * @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
      * @return the element at the offset
      */
-    @SuppressWarnings("unchecked")
-    protected final E lvElement(E[] buffer, long offset) {
-        return (E) UNSAFE.getObjectVolatile(buffer, offset);
+    protected static final Object lvElement(Object[] buffer, long offset) {
+        return UNSAFE.getObjectVolatile(buffer, offset);
     }
 
     @Override

--- a/jctools-core/src/main/java/org/jctools/queues/SpmcArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpmcArrayQueue.java
@@ -135,7 +135,7 @@ public class SpmcArrayQueue<E> extends SpmcArrayQueueL3Pad<E> implements QueuePr
         final long offset = calcElementOffset(currProducerIndex, mask);
         if (null != lvElement(buffer, offset)) {
             long size = currProducerIndex - lvConsumerIndex();
-            
+
             if(size > mask) {
                 return false;
             }
@@ -152,6 +152,7 @@ public class SpmcArrayQueue<E> extends SpmcArrayQueueL3Pad<E> implements QueuePr
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public E poll() {
         long currentConsumerIndex;
         final long currProducerIndexCache = lvProducerIndexCache();
@@ -171,7 +172,7 @@ public class SpmcArrayQueue<E> extends SpmcArrayQueueL3Pad<E> implements QueuePr
         final long offset = calcElementOffset(currentConsumerIndex);
         final E[] lb = buffer;
         // load plain, element happens before it's index becomes visible
-        final E e = lpElement(lb, offset);
+        final E e = (E) lpElement(lb, offset);
         // store ordered, make sure nulling out is visible. Producer is waiting for this value.
         soElement(lb, offset, null);
         return e;
@@ -214,21 +215,21 @@ public class SpmcArrayQueue<E> extends SpmcArrayQueueL3Pad<E> implements QueuePr
             }
         }
     }
-    
+
     @Override
     public boolean isEmpty() {
-        // Order matters! 
+        // Order matters!
         // Loading consumer before producer allows for producer increments after consumer index is read.
         // This ensures the correctness of this method at least for the consumer thread. Other threads POV is not really
         // something we can fix here.
         return (lvConsumerIndex() == lvProducerIndex());
     }
-    
+
     @Override
     public long currentProducerIndex() {
         return lvProducerIndex();
     }
-    
+
     @Override
     public long currentConsumerIndex() {
         return lvConsumerIndex();

--- a/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
@@ -95,9 +95,9 @@ abstract class SpscArrayQueueL3Pad<E> extends SpscArrayQueueConsumerField<E> {
  * <i>2010 - Pisa - SPSC Queues on Shared Cache Multi-Core Systems.pdf<br>
  * 2012 - Junchang- BQueue- Efﬁcient and Practical Queuing.pdf <br>
  * </i> This implementation is wait free.
- * 
+ *
  * @author nitsanw
- * 
+ *
  * @param <E>
  */
 public class SpscArrayQueue<E> extends SpscArrayQueueL3Pad<E>  implements QueueProgressIndicators {
@@ -133,19 +133,20 @@ public class SpscArrayQueue<E> extends SpscArrayQueueL3Pad<E>  implements QueueP
         soElement(buffer, offset, e); // StoreStore
         return true;
     }
-    
+
     /**
      * {@inheritDoc}
      * <p>
      * This implementation is correct for single consumer thread use only.
      */
     @Override
+    @SuppressWarnings("unchecked")
     public E poll() {
         final long index = consumerIndex;
         final long offset = calcElementOffset(index);
         // local load of field to avoid repeated loads after volatile reads
         final E[] lElementBuffer = buffer;
-        final E e = lvElement(lElementBuffer, offset);// LoadLoad
+        final E e = (E) lvElement(lElementBuffer, offset);// LoadLoad
         if (null == e) {
             return null;
         }
@@ -189,20 +190,20 @@ public class SpscArrayQueue<E> extends SpscArrayQueueL3Pad<E>  implements QueueP
     private void soConsumerIndex(long v) {
         UNSAFE.putOrderedLong(this, C_INDEX_OFFSET, v);
     }
-    
+
     private long lvProducerIndex() {
         return UNSAFE.getLongVolatile(this, P_INDEX_OFFSET);
     }
-    
+
     private long lvConsumerIndex() {
         return UNSAFE.getLongVolatile(this, C_INDEX_OFFSET);
     }
-    
+
     @Override
     public long currentProducerIndex() {
         return lvProducerIndex();
     }
-    
+
     @Override
     public long currentConsumerIndex() {
         return lvConsumerIndex();


### PR DESCRIPTION
There are a few unsafe methods that were not 'static final', and this pull request is to provide consistency with how the unsafe methods are called and to provide a hint at compile-time that the compiler should inline those methods.
