### PR TITLE
offerIfBelowThreshold

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/MpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpscArrayQueue.java
@@ -136,6 +136,50 @@ public class MpscArrayQueue<E> extends MpscArrayQueueConsumerField<E> implements
     }
 
     /**
+     * Attempts {@link MpscArrayQueue#offer(E)}} if and only if
+     * the current availability is above the threshold.
+     *
+     * @param e the object to offer onto the queue.
+     * @param threshold as absolute number to be compared to the current queue size.
+     * @return whether the offer is successful.
+     * @since 1.0.1
+     */
+    public boolean offerIfBelowTheshold(final E e, int threshold) {
+        if (null == e) {
+            throw new NullPointerException("Null is not a valid element");
+        }
+        // use a cached view on consumer index (potentially updated in loop)
+        final long mask = this.mask;
+        long consumerIndexCache = lvConsumerIndexCache(); // LoadLoad
+        long currentProducerIndex;
+        do {
+            currentProducerIndex = lvProducerIndex(); // LoadLoad
+            final long wrapPoint = currentProducerIndex - threshold;
+            if (consumerIndexCache <= wrapPoint) {
+                final long currHead = lvConsumerIndex(); // LoadLoad
+                if (currHead <= wrapPoint) {
+                    return false; // FULL :(
+                }
+                else {
+                    // update shared cached value of the consumerIndex
+                    svConsumerIndexCache(currHead); // StoreLoad
+                    // update on stack copy, we might need this value again if we lose the CAS.
+                    consumerIndexCache = currHead;
+                }
+            }
+        } while (!casProducerIndex(currentProducerIndex, currentProducerIndex + 1));
+        /*
+         * NOTE: the new producer index value is made visible BEFORE the element in the array. If we relied on
+         * the index visibility to poll() we would need to handle the case where the element is not visible.
+         */
+
+        // Won CAS, move on to storing
+        final long offset = calcElementOffset(currentProducerIndex, mask);
+        soElement(buffer, offset, e); // StoreStore
+        return true; // AWESOME :)
+    }
+
+    /**
      * {@inheritDoc} <br>
      * 
      * IMPLEMENTATION NOTES:<br>

--- a/jctools-core/src/test/java/org/jctools/queues/MpscArrayQueueTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/MpscArrayQueueTest.java
@@ -1,0 +1,44 @@
+package org.jctools.queues;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests those methods that belong to {@link MpscArrayQueue} only and are therefore
+ * not part of the standard {@link java.util.Queue} API.
+ *
+ * @author Ivan Valeriani
+ */
+public class MpscArrayQueueTest {
+
+    private MpscArrayQueue<Integer> queue;
+
+    @Before
+    public void setUp() throws Exception {
+        this.queue = new MpscArrayQueue<Integer>(16);
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+    }
+
+    @Test
+    public void testOfferWithThreshold() {
+        int i;
+        for (i = 0; i < 8; ++i) {
+            //Offers succeed because current size is below the HWM.
+            Assert.assertTrue(this.queue.offerIfBelowTheshold(Integer.valueOf(i), 8));
+        }
+        //Not anymore, our offer got rejected.
+        Assert.assertFalse(this.queue.offerIfBelowTheshold(Integer.valueOf(i),
+            8));
+        //Also, the threshold is dynamic and different levels can be set for
+        //different task priorities.
+        Assert.assertTrue(this.queue.offerIfBelowTheshold(Integer.valueOf(i),
+            16));
+    }
+
+}


### PR DESCRIPTION
This change is meant to add the ability for this queue to refuse additional items and apply back pressure on the producer 'before it's too late'.
The code is almost identical to offer(E e), with the exception of wrap point being the specified threshold. If threshold == queue-size then semantics match. 