### PR TITLE
SpscUnboundedQueue leaves 1 slot null just before growing.

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/SpscUnboundedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscUnboundedArrayQueue.java
@@ -126,7 +126,7 @@ public class SpscUnboundedArrayQueue<E> extends SpscUnboundedArrayQueueConsumerF
             if (null == lvElement(buffer, lookAheadElementOffset)) {// LoadLoad
                 producerLookAhead = index + lookAheadStep - 1; // joy, there's plenty of room
                 writeToQueue(buffer, e, index, offset);
-            } else if (null != lvElement(buffer, calcWrappedOffset(index + 1, mask))) { // buffer is not full
+            } else if (null == lvElement(buffer, calcWrappedOffset(index + 1, mask))) { // buffer is not full
                 writeToQueue(buffer, e, index, offset);
             } else {
                 linkNewBuffer(buffer, index, offset, e, mask); // add a buffer and link old to new

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscUnboundedAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscUnboundedAtomicArrayQueue.java
@@ -80,7 +80,7 @@ public class SpscUnboundedAtomicArrayQueue<E> extends AbstractQueue<E> implement
             if (null == lvElement(buffer, lookAheadElementOffset)) {// LoadLoad
                 producerLookAhead = index + lookAheadStep - 1; // joy, there's plenty of room
                 return writeToQueue(buffer, e, index, offset);
-            } else if (null != lvElement(buffer, calcWrappedOffset(index + 1, mask))) { // buffer is not full
+            } else if (null == lvElement(buffer, calcWrappedOffset(index + 1, mask))) { // buffer is not full
                 return writeToQueue(buffer, e, index, offset);
             } else {
                 resize(buffer, index, offset, e, mask); // add a buffer and link old to new


### PR DESCRIPTION
In the following program, the queue allocates a new array even though
there is 1 slot available:

```java
SpscUnboundedArrayQueue<Integer> q = new SpscUnboundedArrayQueue<>(256);

for (int i = 0; i < 254; i++) {
    q.offer(i);
}

System.out.println(); // for breakpoint

q.offer(254);

System.out.println(); // for breakpoint
```

Clearly, the queue has room for 255 elements before it has to to grow.
Might not be much of an issue but for small queue sizes (minimum of 8
that the lookahead allows) is a relatively significant lost.