### PR TITLE
Refactored away consumerIndexCache and replaced it with producerLimit

### DIFF
--- a/jctools-core/src/test/java/org/jctools/queues/MpscArrayQueueTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/MpscArrayQueueTest.java
@@ -35,8 +35,13 @@ public class MpscArrayQueueTest {
         //Not anymore, our offer got rejected.
         Assert.assertFalse(this.queue.offerIfBelowTheshold(i,
             8));
+        Assert.assertFalse(this.queue.offerIfBelowTheshold(i, 7));
+        Assert.assertFalse(this.queue.offerIfBelowTheshold(i, 1));
+        Assert.assertFalse(this.queue.offerIfBelowTheshold(i, 0));
+
         //Also, the threshold is dynamic and different levels can be set for
         //different task priorities.
+        Assert.assertTrue(this.queue.offerIfBelowTheshold(i, 9));
         Assert.assertTrue(this.queue.offerIfBelowTheshold(i,
             16));
     }


### PR DESCRIPTION
This pattern is more akin to the producerLookAhead in the SpscArrayQueue.
It affords us some opportunity to remove some calculations from the hot
paths when batch processing elements.

Sadly the offerIfBelowThreshold is a counter intuitive method. Refactoring
it is difficult without changing the semantics. I'd suggest the semantics
of this method given the javdoc & test cases are rather confusing and
perhaps the need reviewing. For backwards compatibility I've preserved
the existing semantics.