### PR TITLE
Wait and lock free alternatives to LongAdder and AtomicLong

### DIFF
--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/counters/Counter.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/counters/Counter.java
@@ -1,0 +1,13 @@
+package org.jctools.jmh.counters;
+
+/**
+ * Adapter interface to benchmark different kind of counters.
+ *
+ * @author Tolstopyatov Vsevolod
+ */
+interface Counter {
+
+    void inc();
+
+    long get();
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/counters/CountersBenchmark.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/counters/CountersBenchmark.java
@@ -1,0 +1,36 @@
+package org.jctools.jmh.counters;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Group)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class CountersBenchmark {
+
+    private Counter counter;
+
+    @Param
+    CountersFactory.CounterType counterType;
+
+    @Setup
+    public void buildCounter() {
+        counter = CountersFactory.build(counterType);
+    }
+
+    @Benchmark
+    @Group("rw")
+    public void inc() {
+        counter.inc();
+    }
+
+    @Benchmark
+    @Group("rw")
+    public long get() {
+        return counter.get();
+    }
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/counters/CountersFactory.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/counters/CountersFactory.java
@@ -1,7 +1,6 @@
 package org.jctools.jmh.counters;
 
-import org.jctools.counters.FixedSizeStripedLongCounterV6;
-import org.jctools.counters.FixedSizeStripedLongCounterV8;
+import org.jctools.counters.FixedSizeStripedLongCounter;
 import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.CompilerControl.Mode;
 
@@ -29,9 +28,11 @@ public class CountersFactory {
             case LongAdder:
                 return new LongAdderCounter();
             case FixedSizeStripedV6:
-                return new FixedSizeStripedCounterV6(STRIPES_COUNT);
+                return new FixedSizeStripedCounter(
+                    org.jctools.counters.CountersFactory.createFixedSizeStripedCounterV6(STRIPES_COUNT));
             case FixedSizeStripedV8:
-                return new FixedSizeStripedCounterV8(STRIPES_COUNT);
+                return new FixedSizeStripedCounter(
+                    org.jctools.counters.CountersFactory.createFixedSizeStripedCounterV8(STRIPES_COUNT));
             default:
                 throw new IllegalArgumentException();
         }
@@ -63,15 +64,23 @@ public class CountersFactory {
         }
     }
 
-    static class FixedSizeStripedCounterV6 extends FixedSizeStripedLongCounterV6 implements Counter {
-        public FixedSizeStripedCounterV6(int stripesCount) {
-            super(stripesCount);
-        }
-    }
+    static class FixedSizeStripedCounter implements Counter {
+        private FixedSizeStripedLongCounter counter;
 
-    static class FixedSizeStripedCounterV8 extends FixedSizeStripedLongCounterV8 implements Counter {
-        public FixedSizeStripedCounterV8(int stripesCount) {
-            super(stripesCount);
+        public FixedSizeStripedCounter(FixedSizeStripedLongCounter impl) {
+            counter = impl;
+        }
+
+        @Override
+        @CompilerControl(Mode.INLINE)
+        public void inc() {
+            counter.inc();
+        }
+
+        @Override
+        @CompilerControl(Mode.INLINE)
+        public long get() {
+            return counter.get();
         }
     }
 }

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/counters/CountersFactory.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/counters/CountersFactory.java
@@ -1,0 +1,77 @@
+package org.jctools.jmh.counters;
+
+import org.jctools.counters.FixedSizeStripedLongCounterV6;
+import org.jctools.counters.FixedSizeStripedLongCounterV8;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.CompilerControl.Mode;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * @author Tolstopyatov Vsevolod
+ */
+public class CountersFactory {
+
+    private static final int STRIPES_COUNT = Runtime.getRuntime().availableProcessors() * 4;
+
+    public enum CounterType {
+        AtomicLong,
+        LongAdder,
+        FixedSizeStripedV6,
+        FixedSizeStripedV8
+    }
+
+    static Counter build(CounterType type) {
+        switch (type) {
+            case AtomicLong:
+                return new AtomicLongCounter();
+            case LongAdder:
+                return new LongAdderCounter();
+            case FixedSizeStripedV6:
+                return new FixedSizeStripedCounterV6(STRIPES_COUNT);
+            case FixedSizeStripedV8:
+                return new FixedSizeStripedCounterV8(STRIPES_COUNT);
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    @SuppressWarnings("serial")
+    static class AtomicLongCounter extends AtomicLong implements Counter {
+
+        @Override
+        @CompilerControl(Mode.INLINE)
+        public void inc() {
+            super.incrementAndGet();
+        }
+    }
+
+    @SuppressWarnings("serial")
+    static class LongAdderCounter extends LongAdder implements Counter {
+
+        @Override
+        @CompilerControl(Mode.INLINE)
+        public void inc() {
+            super.increment();
+        }
+
+        @Override
+        @CompilerControl(Mode.INLINE)
+        public long get() {
+            return super.sum();
+        }
+    }
+
+    static class FixedSizeStripedCounterV6 extends FixedSizeStripedLongCounterV6 implements Counter {
+        public FixedSizeStripedCounterV6(int stripesCount) {
+            super(stripesCount);
+        }
+    }
+
+    static class FixedSizeStripedCounterV8 extends FixedSizeStripedLongCounterV8 implements Counter {
+        public FixedSizeStripedCounterV8(int stripesCount) {
+            super(stripesCount);
+        }
+    }
+}

--- a/jctools-experimental/src/main/java/org/jctools/counters/Counter.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/Counter.java
@@ -1,0 +1,17 @@
+package org.jctools.counters;
+
+/**
+ * Base counter interface.
+ *
+ * @author Tolstopyatov Vsevolod
+ */
+public interface Counter {
+
+    void inc();
+
+    void inc(long delta);
+
+    long get();
+
+    long getAndReset();
+}

--- a/jctools-experimental/src/main/java/org/jctools/counters/CountersFactory.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/CountersFactory.java
@@ -10,7 +10,7 @@ public final class CountersFactory {
     private CountersFactory() {
     }
 
-    public static Counter createFixedSizeStripedCounter(int stripesCount) {
+    public static FixedSizeStripedLongCounter createFixedSizeStripedCounter(int stripesCount) {
         // Assuming that if Unsafe has getAndSet(Object, Long, Object) then it has
         // all JDK 8+ methods like getAndAddX, getAndSetX etc.
         if (UnsafeAccess.SUPPORTS_GET_AND_SET) {
@@ -18,5 +18,13 @@ public final class CountersFactory {
         } else {
             return new FixedSizeStripedLongCounterV6(stripesCount);
         }
+    }
+
+    public static FixedSizeStripedLongCounter createFixedSizeStripedCounterV6(int stripesCount) {
+        return new FixedSizeStripedLongCounterV6(stripesCount);
+    }
+
+    public static FixedSizeStripedLongCounter createFixedSizeStripedCounterV8(int stripesCount) {
+        return new FixedSizeStripedLongCounterV8(stripesCount);
     }
 }

--- a/jctools-experimental/src/main/java/org/jctools/counters/CountersFactory.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/CountersFactory.java
@@ -1,0 +1,22 @@
+package org.jctools.counters;
+
+import org.jctools.util.UnsafeAccess;
+
+/**
+ * @author Tolstopyatov Vsevolod
+ */
+public final class CountersFactory {
+
+    private CountersFactory() {
+    }
+
+    public static Counter createFixedSizeStripedCounter(int stripesCount) {
+        // Assuming that if Unsafe has getAndSet(Object, Long, Object) then it has
+        // all JDK 8+ methods like getAndAddX, getAndSetX etc.
+        if (UnsafeAccess.SUPPORTS_GET_AND_SET) {
+            return new FixedSizeStripedLongCounterV8(stripesCount);
+        } else {
+            return new FixedSizeStripedLongCounterV6(stripesCount);
+        }
+    }
+}

--- a/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounter.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounter.java
@@ -1,0 +1,122 @@
+package org.jctools.counters;
+
+import org.jctools.util.JvmInfo;
+import org.jctools.util.Pow2;
+import sun.misc.Unsafe;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+
+/**
+ * Basic class representing static striped long counter with
+ * common mechanics for implementors.
+ *
+ * @author Tolstopyatov Vsevolod
+ */
+abstract class FixedSizeStripedLongCounter extends PaddedHeader implements Counter {
+
+    private static final int LONG_ARRAY_BASE = Unsafe.ARRAY_LONG_BASE_OFFSET;
+    private static final int LONG_SCALE_SHIFT = 3;
+    private static final int PADDING = JvmInfo.CACHE_LINE_SIZE / 8;
+
+    protected final long[] cells;
+    protected final int mask;
+
+    public FixedSizeStripedLongCounter(int stripesCount) {
+        int size = Pow2.roundToPowerOfTwo(PADDING * stripesCount);
+        cells = new long[size];
+        /*
+         * Trick to avoid cells.length modulo + padding alignment.
+         * It's faster to use precalculated mask, because
+         * JIT can't deduce that cells is final field, throw away length dec call
+         * and fold it with consecutive 'and' op for alignment.
+         */
+        mask = (cells.length - 1) & ~(PADDING - 1);
+    }
+
+    @Override
+    public void inc() {
+        inc(1L);
+    }
+
+    @Override
+    public void inc(long delta) {
+        inc(index(), delta);
+    }
+
+    @Override
+    public long get() {
+        long result = 0L;
+        for (int i = 0; i < cells.length; i += PADDING) {
+            result += UNSAFE.getLongVolatile(cells, LONG_ARRAY_BASE + (i << LONG_SCALE_SHIFT));
+        }
+        return result;
+    }
+
+    @Override
+    public long getAndReset() {
+        long result = 0L;
+        for (int i = 0; i < cells.length; i += PADDING) {
+            result += getAndReset(LONG_ARRAY_BASE + (i << LONG_SCALE_SHIFT));
+        }
+        return result;
+    }
+
+    protected abstract void inc(long offset, long value);
+
+    protected abstract long getAndReset(long offset);
+
+    private int index() {
+        int index = probe() & mask;
+        return LONG_ARRAY_BASE + (index << LONG_SCALE_SHIFT);
+    }
+
+
+    /**
+     * Returns the probe value for the current thread.
+     * If target JDK version is 7 or higher, than ThreadLocalRandom-specific
+     * value will be used, xorshift with thread id otherwise.
+     */
+    private int probe() {
+        // Fast path for reliable well-distributed probe, available from JDK 7+.
+        // As long as PROBE is final this branch will be inlined.
+        if (PROBE != -1) {
+            int probe;
+            if ((probe = UNSAFE.getInt(Thread.currentThread(), PROBE)) == 0) {
+                ThreadLocalRandom.current(); // force initialization
+                probe = UNSAFE.getInt(Thread.currentThread(), PROBE);
+            }
+            return probe;
+        }
+
+        /*
+         * Else use much worse (for values distribution) method:
+         * Mix thread id with golden ratio and then xorshift it
+         * to spread consecutive ids (see Knuth multiplicative method as reference).
+         */
+        int probe = (int) ((Thread.currentThread().getId() * 0x9e3779b9) & Integer.MAX_VALUE);
+        // xorshift
+        probe ^= probe << 13;
+        probe ^= probe >>> 17;
+        probe ^= probe << 5;
+        return probe;
+    }
+
+    private static final long PROBE = getProbeOffset();
+
+    private static long getProbeOffset() {
+        try {
+            Class<?> tk = Thread.class;
+            return UNSAFE.objectFieldOffset(tk.getDeclaredField("threadLocalRandomProbe"));
+
+        } catch (NoSuchFieldException e) {
+            return -1L;
+        }
+    }
+}
+
+abstract class PaddedHeader {
+    long l01, l02, l03, l04, l05, l06, l07, l08;
+    long l9, l10, l11, l12, l13, l14, l15, l16;
+}

--- a/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounter.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounter.java
@@ -14,7 +14,7 @@ import static org.jctools.util.UnsafeAccess.UNSAFE;
  *
  * @author Tolstopyatov Vsevolod
  */
-abstract class FixedSizeStripedLongCounter extends PaddedHeader implements Counter {
+public abstract class FixedSizeStripedLongCounter extends PaddedHeader implements Counter {
 
     private static final int LONG_ARRAY_BASE = Unsafe.ARRAY_LONG_BASE_OFFSET;
     private static final int LONG_SCALE_SHIFT = 3;

--- a/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounterV6.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounterV6.java
@@ -16,6 +16,8 @@ public class FixedSizeStripedLongCounterV6 extends FixedSizeStripedLongCounter {
 
     @Override
     protected void inc(long offset, long delta) {
+        // Local load to avoid reloading after volatile read
+        long[] cells = this.cells;
         long v;
         do {
             v = UNSAFE.getLongVolatile(cells, offset);
@@ -24,6 +26,8 @@ public class FixedSizeStripedLongCounterV6 extends FixedSizeStripedLongCounter {
 
     @Override
     protected long getAndReset(long offset) {
+        // Local load to avoid reloading after volatile read
+        long[] cells = this.cells;
         long v;
         do {
             v = UNSAFE.getLongVolatile(cells, offset);

--- a/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounterV6.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounterV6.java
@@ -8,7 +8,7 @@ import static org.jctools.util.UnsafeAccess.UNSAFE;
  *
  * @author Tolstopyatov Vsevolod
  */
-public class FixedSizeStripedLongCounterV6 extends FixedSizeStripedLongCounter {
+class FixedSizeStripedLongCounterV6 extends FixedSizeStripedLongCounter {
 
     public FixedSizeStripedLongCounterV6(int stripesCount) {
         super(stripesCount);

--- a/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounterV6.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounterV6.java
@@ -1,0 +1,34 @@
+package org.jctools.counters;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+
+/**
+ * Lock-free implementation of striped counter using
+ * CAS primitives.
+ *
+ * @author Tolstopyatov Vsevolod
+ */
+public class FixedSizeStripedLongCounterV6 extends FixedSizeStripedLongCounter {
+
+    public FixedSizeStripedLongCounterV6(int stripesCount) {
+        super(stripesCount);
+    }
+
+    @Override
+    protected void inc(long offset, long delta) {
+        long v;
+        do {
+            v = UNSAFE.getLongVolatile(cells, offset);
+        } while (!UNSAFE.compareAndSwapLong(cells, offset, v, v + delta));
+    }
+
+    @Override
+    protected long getAndReset(long offset) {
+        long v;
+        do {
+            v = UNSAFE.getLongVolatile(cells, offset);
+        } while (!UNSAFE.compareAndSwapLong(cells, offset, v, 0L));
+
+        return v;
+    }
+}

--- a/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounterV8.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounterV8.java
@@ -8,7 +8,7 @@ import static org.jctools.util.UnsafeAccess.UNSAFE;
  *
  * @author Tolstopyatov Vsevolod
  */
-public class FixedSizeStripedLongCounterV8 extends FixedSizeStripedLongCounter {
+class FixedSizeStripedLongCounterV8 extends FixedSizeStripedLongCounter {
 
     public FixedSizeStripedLongCounterV8(int stripesCount) {
         super(stripesCount);

--- a/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounterV8.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounterV8.java
@@ -1,0 +1,26 @@
+package org.jctools.counters;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+
+/**
+ * Wait-free implementation of striped counter using
+ * Java 8 Unsafe intrinsics (lock addq and lock xchg).
+ *
+ * @author Tolstopyatov Vsevolod
+ */
+public class FixedSizeStripedLongCounterV8 extends FixedSizeStripedLongCounter {
+
+    public FixedSizeStripedLongCounterV8(int stripesCount) {
+        super(stripesCount);
+    }
+
+    @Override
+    protected void inc(long offset, long delta) {
+        UNSAFE.getAndAddLong(cells, offset, delta);
+    }
+
+    @Override
+    protected long getAndReset(long offset) {
+        return UNSAFE.getAndSetLong(cells, offset, 0L);
+    }
+}

--- a/jctools-experimental/src/test/java/org/jctools/counters/FixedSizeStripedLongCounterTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/counters/FixedSizeStripedLongCounterTest.java
@@ -1,0 +1,77 @@
+package org.jctools.counters;
+
+import org.jctools.util.JvmInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Tolstopyatov Vsevolod
+ */
+@RunWith(Parameterized.class)
+public class FixedSizeStripedLongCounterTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> parameters() {
+        int stripesCount = JvmInfo.CPUs * 2;
+        ArrayList<Object[]> list = new ArrayList<>();
+        list.add(new Counter[]{new FixedSizeStripedLongCounterV6(stripesCount)});
+        list.add(new Counter[]{new FixedSizeStripedLongCounterV8(stripesCount)});
+        return list;
+    }
+
+    private final Counter counter;
+
+    public FixedSizeStripedLongCounterTest(Counter counter) {
+        this.counter = counter;
+    }
+
+    @Test
+    public void testCounterSanity() {
+        long expected = 1000L;
+        for (int i = 0; i < expected; i++) {
+            counter.inc();
+        }
+
+        assertSanity(expected);
+    }
+
+    @Test
+    public void testMultipleThreadsCounterSanity() throws Exception {
+        int threadsCount = JvmInfo.CPUs;
+        int workUnit = 100;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch finishLatch = new CountDownLatch(threadsCount);
+
+        for (int i = 0; i < threadsCount; i++) {
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    for (int j = 0; j < workUnit; j++) {
+                        counter.inc();
+                    }
+                    finishLatch.countDown();
+                } catch (Exception e) {
+                    fail();
+                }
+            }).start();
+        }
+
+        startLatch.countDown();
+        finishLatch.await();
+        assertSanity(workUnit * threadsCount);
+    }
+
+    private void assertSanity(long expected) {
+        assertEquals(expected, counter.get());
+        assertEquals(expected, counter.getAndReset());
+        assertEquals(0L, counter.get());
+    }
+}


### PR DESCRIPTION
As part of #36.

Alternative of LongAdder, which uses static-sized inlined stripes and doesn't try to resize adaptively.
So it benefits from less padding and dereferencing overhead (compared to @Contended Cell class from Striped64), no complicated adaptive-resizing control flow and uses much more performant lock xadd (or lock addq) instruction (via Unsafe intrinsic) instead of lock cmpxchg (which is used in LongAdder instead of xadd only to indicate contention fact). Tradeoff between inc/get performance could be tuned via stripes count constructor parameter. Less performant version of counter for Java 6 included.
Assembly of inc method is [here](https://gist.github.com/qwwdfsad/58f8657aa62799492780).

Some interesting benchmarks results are [here](https://gist.github.com/qwwdfsad/0f85377f004c9328d000) (different cores amount/cross-socket modes, but always single reader/multiple writers). Benchmarks were performed on 32 cores Xeon with disabled hyper-threading (so in fact there was 16 cores), 8u72, 32 stripes (not cores * 4 as stated in current benchmark code) and with a little bit slower index method (it was 'dec' + two 'and' ops instead of single 'and' as now). Similar results are reproducible on my i7.

If you are going to benchmark this code manually, then be aware of [JDK-6515172](https://bugs.openjdk.java.net/browse/JDK-6515172) (affects LongAdder measurements)