### PR TITLE
Add JMH benchmark for concurrent maps.

### DIFF
--- a/jctools-benchmarks/src/main/java/org/jctools/maps/nhbm_test/SimpleRandom.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/maps/nhbm_test/SimpleRandom.java
@@ -1,0 +1,26 @@
+package org.jctools.maps.nhbm_test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+// Fairly fast random numbers
+public final class SimpleRandom {
+    private final static long multiplier = 0x5DEECE66DL;
+    private final static long addend = 0xBL;
+    private final static long mask = (1L << 48) - 1;
+    static final AtomicLong seq = new AtomicLong(-715159705);
+    private long seed;
+
+    public SimpleRandom() {
+        seed = System.nanoTime() + seq.getAndAdd(129);
+    }
+
+    public int nextInt() {
+        return next();
+    }
+
+    public int next() {
+        long nextseed = (seed * multiplier + addend) & mask;
+        seed = nextseed;
+        return ((int) (nextseed >>> 17)) & 0x7FFFFFFF;
+    }
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/maps/nhbm_test/jmh/ConcurrentMapThroughput.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/maps/nhbm_test/jmh/ConcurrentMapThroughput.java
@@ -1,0 +1,158 @@
+package org.jctools.maps.nhbm_test.jmh;
+
+import org.jctools.maps.NonBlockingHashMap;
+import org.jctools.maps.nhbm_test.SimpleRandom;
+import org.jctools.util.Pow2;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.ThreadParams;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode({Mode.Throughput})
+@Warmup(iterations = 2, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 6, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class ConcurrentMapThroughput {
+
+    @Param(value = {"NonBlockingHashMap", "ConcurrentHashMap"})
+    private String implementation;
+
+    @Param(value = "50")
+    private static int readRatio;
+
+    @Param(value = "100000")
+    private static int tableSize;
+
+    private static String testData[];
+    private static int _gr, _pr;
+
+    private Map<String, String> map;
+
+    @Setup(Level.Trial)
+    public void createMap(ThreadParams threads) {
+        validateParameters();
+        createImplementation(threads);
+        setRatios();
+    }
+
+    private void validateParameters() {
+        if (readRatio < 0 || readRatio > 100) {
+            throw new IllegalArgumentException("readRatio must be a value between 0 and 100");
+        }
+        if (tableSize < 100 || tableSize > Pow2.MAX_POW2) {
+            throw new IllegalArgumentException("tableSize must be a value between 100 and " + Pow2.MAX_POW2);
+        }
+    }
+
+    private void createImplementation(ThreadParams threads) {
+        if ("ConcurrentHashMap".equalsIgnoreCase(implementation)) {
+            map = new ConcurrentHashMap<String, String>(16, 0.75f, 16);
+        } else if ("NonBlockingHashMap".equalsIgnoreCase(implementation)) {
+            map = new NonBlockingHashMap<String, String>();
+        } else if ("HashMap".equalsIgnoreCase(implementation)){
+            map = threads.getGroupCount() == 1 ?
+                    new HashMap<String, String>() : Collections.synchronizedMap(new HashMap<String, String>());
+        } else{
+            throw new IllegalArgumentException("Unsupported map: " + implementation);
+        }
+    }
+
+    private void setRatios() {
+        _gr = (readRatio << 20) / 100;
+        _pr = (((1 << 20) - _gr) >> 1) + _gr;
+    }
+
+    @Setup(Level.Trial)
+    public void prepareMap() {
+        testData = new String[Pow2.roundToPowerOfTwo(tableSize)];
+        for (int i = 0; i < testData.length; i++) {
+            testData[i] = String.valueOf(i) + "abc" + String.valueOf(i * 17 + 123);
+        }
+
+        Random rand = new Random();
+
+        int sz = map.size();
+        while (sz + 1024 < tableSize) {
+            int idx = rand.nextInt();
+            for (int i = 0; i < 1024; i++) {
+                String key = testData[idx & (testData.length - 1)];
+                map.put(key, key);
+                idx++;
+            }
+            sz = map.size();
+        }
+
+        while (sz < ((tableSize >> 1) + (tableSize >> 3))) {
+            int trip = 0;
+            int idx = rand.nextInt();
+            while (true) {
+                String key = testData[idx & (testData.length - 1)];
+                if (sz < tableSize) {
+                    if (map.put(key, key) == null) {
+                        sz++;
+                        break;
+                    }
+                } else {
+                    if (map.remove(key) != null) {
+                        sz--;
+                        break;
+                    }
+                }
+                idx++;
+                if ((trip & 15) == 15)
+                    idx = rand.nextInt();
+                if (trip++ > 1024 * 1024) {
+                    if (trip > 1024 * 1024 + 100)
+                        throw new AssertionError(
+                                String.format("barf trip %d %d numkeys=%d", sz, map.size(), testData.length));
+                    System.out.println(key);
+                }
+            }
+        }
+
+        if (sz != map.size()) {
+            throw new AssertionError("size does not match table contents sz=" + sz + " size()=" + map.size());
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class ThreadState {
+        private SimpleRandom random = new SimpleRandom();
+        int next() { return random.next(); }
+    }
+
+    @Benchmark
+    @Threads(2)
+    public String randomGetPutRemove(ThreadState state) {
+        String key = testData[state.next() & (testData.length - 1)];
+        int x = state.next() & ((1 << 20) - 1);
+        if (x < _gr) {
+            String val = map.get(key);
+            if (val != null && !val.equals(key))
+                throw new AssertionError("Mismatched key=" + key + " and val=" + val);
+            return val;
+        } else if (x < _pr) {
+            return map.putIfAbsent(key, key);
+        } else {
+            return map.remove(key);
+        }
+    }
+
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/maps/nhbm_test/jmh/ConcurrentMapThroughput.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/maps/nhbm_test/jmh/ConcurrentMapThroughput.java
@@ -31,6 +31,11 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class ConcurrentMapThroughput {
 
+    /*
+     * Note that in NonBlockingHashMap, puts that update an entry to the same reference are
+     * short circuited and do not mutate the hash table. Such operations are equivalent to a get.
+     */
+
     @Param(value = {"NonBlockingHashMap", "ConcurrentHashMap"})
     private String implementation;
 

--- a/jctools-benchmarks/src/main/java/org/jctools/maps/nhbm_test/perf_hash_test.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/maps/nhbm_test/perf_hash_test.java
@@ -3,7 +3,6 @@ package org.jctools.maps.nhbm_test;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.jctools.maps.NonBlockingHashMap;
 
@@ -478,29 +477,6 @@ public class perf_hash_test extends Thread {
         }
         // We stopped; report results into shared result structure
         return get_ops + put_ops + del_ops;
-    }
-
-    // Fairly fast random numbers
-    public static final class SimpleRandom {
-        private final static long multiplier = 0x5DEECE66DL;
-        private final static long addend = 0xBL;
-        private final static long mask = (1L << 48) - 1;
-        static final AtomicLong seq = new AtomicLong(-715159705);
-        private long seed;
-
-        SimpleRandom() {
-            seed = System.nanoTime() + seq.getAndAdd(129);
-        }
-
-        public int nextInt() {
-            return next();
-        }
-
-        public int next() {
-            long nextseed = (seed * multiplier + addend) & mask;
-            seed = nextseed;
-            return ((int) (nextseed >>> 17)) & 0x7FFFFFFF;
-        }
     }
 
 }


### PR DESCRIPTION
This is pretty much a straight up port of the existing perf_hash_test to JMH, per #108. I moved SimpleRandom out of perf_hash_test.

Result of running both on the same machine:

```
jctools-benchmarks git:(nbhm-jmh)% for t in 2 4 6 8; do java -jar target/microbenchmarks.jar ConcurrentMapsThroughput.rand -t $t -f 1; done

# Threads: 2 threads, will synchronize iterations
# Benchmark: org.jctools.maps.nhbm_test.jmh.ConcurrentMapsThroughput.randomGetPutRemove
# Parameters: (implementation = NonBlockingHashMap, readRatio = 50, tableSize = 100000)

Benchmark                                      (implementation)  (readRatio)  (tableSize)   Mode  Cnt         Score         Error  Units
ConcurrentMapsThroughput.randomGetPutRemove  NonBlockingHashMap           50       100000  thrpt    6  17923933.571 ±  912895.637  ops/s
ConcurrentMapsThroughput.randomGetPutRemove   ConcurrentHashMap           50       100000  thrpt    6  23668440.241 ± 5684267.690  ops/s

###

# Threads: 4 threads, will synchronize iterations
# Benchmark: org.jctools.maps.nhbm_test.jmh.ConcurrentMapsThroughput.randomGetPutRemove
# Parameters: (implementation = NonBlockingHashMap, readRatio = 50, tableSize = 100000)

Benchmark                                      (implementation)  (readRatio)  (tableSize)   Mode  Cnt         Score         Error  Units
ConcurrentMapsThroughput.randomGetPutRemove  NonBlockingHashMap           50       100000  thrpt    6  44864770.568 ± 1202113.075  ops/s
ConcurrentMapsThroughput.randomGetPutRemove   ConcurrentHashMap           50       100000  thrpt    6  43945366.601 ± 3180110.185  ops/s

###

# Threads: 6 threads, will synchronize iterations
# Benchmark: org.jctools.maps.nhbm_test.jmh.ConcurrentMapsThroughput.randomGetPutRemove
# Parameters: (implementation = NonBlockingHashMap, readRatio = 50, tableSize = 100000)

Benchmark                                      (implementation)  (readRatio)  (tableSize)   Mode  Cnt         Score         Error  Units
ConcurrentMapsThroughput.randomGetPutRemove  NonBlockingHashMap           50       100000  thrpt    6  57554032.876 ±  335786.149  ops/s
ConcurrentMapsThroughput.randomGetPutRemove   ConcurrentHashMap           50       100000  thrpt    6  56251688.387 ± 3140116.465  ops/s

###

# Threads: 8 threads, will synchronize iterations
# Benchmark: org.jctools.maps.nhbm_test.jmh.ConcurrentMapsThroughput.randomGetPutRemove
# Parameters: (implementation = NonBlockingHashMap, readRatio = 50, tableSize = 100000)

Benchmark                                      (implementation)  (readRatio)  (tableSize)   Mode  Cnt         Score         Error  Units
ConcurrentMapsThroughput.randomGetPutRemove  NonBlockingHashMap           50       100000  thrpt    6  64094875.527 ± 2180806.338  ops/s
ConcurrentMapsThroughput.randomGetPutRemove   ConcurrentHashMap           50       100000  thrpt    6  62433923.436 ± 2661512.313  ops/s


jctools-benchmarks git:(nbhm-jmh)% java -cp ... org.jctools.maps.nhbm_test.perf_hash_test
50% gets, 25% inserts, 25% removes, table_size=100000 Best
Threads from 2 to 8 by 2
Warmup -variance:
===     CHM_16    2  cnts/sec=   22514871
===  NBHashMap    2  cnts/sec=   16893822 size=1048578
==== HashMap  Threads   Trial:    0          1          2          3          4          5          6          Avg      Stddev
===     CHM_16    2  cnts/sec=   17159725   24732722   24932298   25377222   23633198   25029976   25464857   24898332 (+/- 0%)  65377
===  NBHashMap    2  cnts/sec=   17281654   18891777   17008697   17564187   19901123   19047840   19239117   18501268 (+/- 4%)  65841 size=1048578
===     CHM_16    4  cnts/sec=   45679183   45948000   45803727   45934142   45873051   45820472   45274057   45967458 (+/- 0%)  65452
===  NBHashMap    4  cnts/sec=   45759998   46562757   46239087   46287162   46085904   45991481   46322006   46204051 (+/- 0%)  65443 size=1048578
===     CHM_16    6  cnts/sec=   57408141   58173032   58174207   58186218   58161588   58219358   58191284   58177819 (+/- 0%)  65507
===  NBHashMap    6  cnts/sec=   57648986   58911525   59107223   58633843   58790711   58970249   58758884   58820373 (+/- 0%)  65471 size=1048578
===     CHM_16    8  cnts/sec=   64764567   64139703   64566574   64774410   65508813   65302646   65318703   64947207 (+/- 0%)  65630
===  NBHashMap    8  cnts/sec=   65516278   63649737   65449784   66149245   65772432   65584908   65647868   65583018 (+/- 0%)  65458 size=1048578
```

Bonus: now supports HashMap as a baseline (this is not enabled by default). If run in a single-
threaded mode, the HashMap will *not* be synchronized.