### PR TITLE
Added profile "eclipse-dev"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,4 +96,16 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!-- For use by eclipse users using the m2 plugin that gets the source 
+                and target versions mixed up. With this you can go to right click on the projects, 
+                select "Maven" and "Select Profiles" then check "eclipse-dev". -->
+            <id>eclipse-dev</id>
+            <properties>
+                <java.version>${java.test.version}</java.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This profile may be enabled in the Eclipse IDE to help the Maven
integration to decide which compiler version to use.

This is optional and non-functional. It comes with the risks that you may
not notice if the source violates Java 6 syntax until you build through
maven. On the other hand if you are doing eclipse development and not
toggling the compiler versions you probably aren't running the tests.

To use with a new project:

- File > Import
- When selecting a project expand the "Advanced" section at the bottom
- Enter "eclipse-dev" into the profiles
- Continue about your business

To use with an existing project:
- Right click on the projects
- Select "Maven" > "Select Profiles"
- Check "eclipse-dev"
- Get back to work!