### PR TITLE
Generate OSGi Manifest during package phase

### DIFF
--- a/jctools-core/pom.xml
+++ b/jctools-core/pom.xml
@@ -10,24 +10,35 @@
 	<artifactId>jctools-core</artifactId>
 	<name>Java Concurrency Tools Core Library</name>
 	<description>Java Concurrency Tools Core Library</description>
-	<packaging>jar</packaging>
-	
-    <dependencies>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+	<packaging>bundle</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-all</artifactId>
+			<version>${hamcrest.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.5.4</version>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Import-Package>sun.misc;resolution:=optional</Import-Package>
+					</instructions>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
@@ -73,7 +84,6 @@
 		</plugins>
 	</build>
 
-	
 	<reporting>
 		<plugins>
 			<plugin>
@@ -89,4 +99,3 @@
 		</plugins>
 	</reporting>
 </project>
-


### PR DESCRIPTION
As discussed in #126
this will turn the maven packaging phase into making an OSGI bundle instead of a JAR file.
The only actual difference is that the felix bundle plugin analyzes imports and exports all classes.

The resulting manifest (build on my machine) looks like:
```
Manifest-Version: 1.0
Bnd-LastModified: 1472494973353
Build-Jdk: 1.8.0_71
Built-By: fabian
Bundle-Description: Java Concurrency Tools Core Library
Bundle-DocURL: https://github.com/JCTools
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
Bundle-ManifestVersion: 2
Bundle-Name: Java Concurrency Tools Core Library
Bundle-SymbolicName: org.jctools.core
Bundle-Version: 1.3.0.SNAPSHOT
Created-By: Apache Maven Bundle Plugin
Export-Package: org.jctools.queues.atomic;version="1.3.0";uses:="org.jct
 ools.queues,org.jctools.queues.spec",org.jctools.queues;version="1.3.0"
 ;uses:="org.jctools.queues.spec",org.jctools.queues.spec;version="1.3.0
 ",org.jctools.util;version="1.3.0";uses:="sun.misc"
Import-Package: sun.misc
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))"
Tool: Bnd-2.4.1.201501161923
```

It is worth noting that "sun.misc" is noted as required import, so this will not work on an j9 for example. I have not checked all references, but if it is handled gracefully (like catching class not found) then we should mark it as optional. 
Let me know if thats the case

PS: some whitespace changes done by my editor. i can remove them if desired.
