### PR TITLE
Patch org.jctools.util.UnsafeAccess for Android usage

### DIFF
--- a/jctools-core/src/main/java/org/jctools/util/UnsafeAccess.java
+++ b/jctools-core/src/main/java/org/jctools/util/UnsafeAccess.java
@@ -15,6 +15,7 @@ package org.jctools.util;
 
 import sun.misc.Unsafe;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -28,29 +29,42 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
  * <li>To construct flavors of {@link AtomicReferenceArray}.
  * <li>Other use cases exist but are not present in this library yet.
  * </ol>
- * 
+ *
  * @author nitsanw
- * 
+ *
  */
 public class UnsafeAccess {
     public static final boolean SUPPORTS_GET_AND_SET;
     public static final Unsafe UNSAFE;
     static {
+        Unsafe instance;
         try {
             final Field field = Unsafe.class.getDeclaredField("theUnsafe");
             field.setAccessible(true);
-            UNSAFE = (Unsafe) field.get(null);
-        } catch (Exception e) {
-            SUPPORTS_GET_AND_SET = false;
-            throw new RuntimeException(e);
+            instance = (Unsafe) field.get(null);
+        } catch (Exception ignored) {
+            // Some platforms, notably Android, might not have a sun.misc.Unsafe
+            // implementation with a private `theUnsafe` static instance. In this
+            // case we can try and call the default constructor, which proves
+            // sufficient for Android usage.
+            try {
+                Constructor<Unsafe> c = sun.misc.Unsafe.class.getDeclaredConstructor();
+                c.setAccessible(true);
+                instance = c.newInstance();
+            } catch (Exception e) {
+                SUPPORTS_GET_AND_SET = false;
+                throw new RuntimeException(e);
+            }
         }
+
         boolean getAndSetSupport = false;
         try {
             Unsafe.class.getMethod("getAndSetObject", Object.class, Long.TYPE,Object.class);
             getAndSetSupport = true;
-        } catch (Exception e) {
+        } catch (Exception ignored) {
         }
+        
+        UNSAFE = instance;
         SUPPORTS_GET_AND_SET = getAndSetSupport;
     }
-
 }

--- a/jctools-core/src/main/java/org/jctools/util/UnsafeAccess.java
+++ b/jctools-core/src/main/java/org/jctools/util/UnsafeAccess.java
@@ -14,7 +14,6 @@
 package org.jctools.util;
 
 import sun.misc.Unsafe;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -48,7 +47,7 @@ public class UnsafeAccess {
             // case we can try and call the default constructor, which proves
             // sufficient for Android usage.
             try {
-                Constructor<Unsafe> c = sun.misc.Unsafe.class.getDeclaredConstructor();
+                Constructor<Unsafe> c = Unsafe.class.getDeclaredConstructor();
                 c.setAccessible(true);
                 instance = c.newInstance();
             } catch (Exception e) {
@@ -63,7 +62,7 @@ public class UnsafeAccess {
             getAndSetSupport = true;
         } catch (Exception ignored) {
         }
-        
+
         UNSAFE = instance;
         SUPPORTS_GET_AND_SET = getAndSetSupport;
     }


### PR DESCRIPTION
On Android, at least older versions, we cannot rely on `theUnsafe` being available as a `private static` instance on the `sun.misc.Unsafe` class.

Here's the implementation of sun.misc.Unsafe for Android 2.3: https://android.googlesource.com/platform/libcore/+/gingerbread/luni/src/main/java/sun/misc/Unsafe.java#32 - so the problem is that for Gingerbread this instance was called `THE_ONE`.

This patch modifies `UnsafeAccess` to first try and fetch `theUnsafe`, but if that fails then it tries to initiate `sun.misc.Unsafe` by calling its default constructor, which should work for as long as the `sun.misc.Unsafe` class exists.