### PR TITLE
Channel proxies with references

### DIFF
--- a/jctools-benchmarks/pom.xml
+++ b/jctools-benchmarks/pom.xml
@@ -36,7 +36,7 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>${jmh-core.version}</version>
             <scope>provided</scope>
-        </dependency>        
+        </dependency>
     </dependencies>
 
     <build>

--- a/jctools-benchmarks/src/main/java/org/jctools/channels/spsc/SpscProxyChannelBenchmark.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/channels/spsc/SpscProxyChannelBenchmark.java
@@ -1,0 +1,631 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.channels.spsc;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jctools.channels.proxy.ProxyChannel;
+import org.jctools.channels.proxy.ProxyChannelFactory;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.infra.Control;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+public class SpscProxyChannelBenchmark {
+
+    private static final int CAPACITY = 10000;
+
+    public interface BenchIFace {
+
+        void noArgs();
+
+        void onePrimitiveArg(int x);
+
+        void twoMixedLengthPrimitiveArgs(int x, long y);
+
+        void oneObjectArg(Object x);
+
+        void oneReferenceArg(CustomType x);
+
+        // I'm curious is there's a performance cost of switching between the ref queue and the bytebuffer
+        void tenMixedArgs(int i,
+                Object o,
+                long l,
+                CustomType c0,
+                double d,
+                CustomType c1,
+                float f,
+                CustomType c2,
+                boolean b,
+                CustomType c3);
+
+        // The first value is 'type':int that is 4 bytes which renders all of this unaligned
+        void unalignedPrimitiveArgs(
+                long l1,
+                double d1,
+                long l2,
+                double d2,
+                long l3,
+                double d3,
+                long l4,
+                double d4,
+                long l5,
+                double d5,
+                long l6,
+                double d6,
+                long l7,
+                double d7,
+                long l8,
+                double d8,
+                int i);
+
+        // The first value is 'type':int that is implicit so we start with a 4 byte value first then all 8 bytes, then all 4 bytes, and so on
+        void alignedPrimitiveArgs(
+                int i,
+                long l1,
+                double d1,
+                long l2,
+                double d2,
+                long l3,
+                double d3,
+                long l4,
+                double d4,
+                long l5,
+                double d5,
+                long l6,
+                double d6,
+                long l7,
+                double d7,
+                long l8,
+                double d8);
+    }
+
+    public static class CustomType {
+
+    }
+
+    private static final class BenchImpl implements BenchIFace {
+        private final long tokens;
+
+        public BenchImpl(final long tokens) {
+            super();
+            this.tokens = tokens;
+        }
+
+        @Override
+        public void noArgs() {
+            Blackhole.consumeCPU(this.tokens);
+        }
+
+        @Override
+        public void onePrimitiveArg(final int x) {
+            Blackhole.consumeCPU(this.tokens);
+        }
+
+        @Override
+        public void twoMixedLengthPrimitiveArgs(final int x, final long y) {
+            Blackhole.consumeCPU(this.tokens);
+        }
+
+        @Override
+        public void oneObjectArg(final Object x) {
+            Blackhole.consumeCPU(this.tokens);
+        }
+
+        @Override
+        public void oneReferenceArg(final CustomType x) {
+            Blackhole.consumeCPU(this.tokens);
+        }
+
+        @Override
+        public void tenMixedArgs(final int i,
+                final Object o,
+                final long l,
+                final CustomType c0,
+                final double d,
+                final CustomType c1,
+                final float f,
+                final CustomType c2,
+                final boolean b,
+                final CustomType c3) {
+            Blackhole.consumeCPU(this.tokens);
+        }
+
+        @Override
+        public void unalignedPrimitiveArgs(
+                long l1,
+                double d1,
+                long l2,
+                double d2,
+                long l3,
+                double d3,
+                long l4,
+                double d4,
+                long l5,
+                double d5,
+                long l6,
+                double d6,
+                long l7,
+                double d7,
+                long l8,
+                double d8,
+                int i) {
+            Blackhole.consumeCPU(this.tokens);
+        }
+
+        @Override
+        public void alignedPrimitiveArgs(int i,
+                long l1,
+                double d1,
+                long l2,
+                double d2,
+                long l3,
+                double d3,
+                long l4,
+                double d4,
+                long l5,
+                double d5,
+                long l6,
+                double d6,
+                long l7,
+                double d7,
+                long l8,
+                double d8) {
+            Blackhole.consumeCPU(this.tokens);
+        }
+
+    }
+
+    @AuxCounters
+    @State(Scope.Thread)
+    public static class ProcessorCounters {
+        public long processed;
+        public long processFailed;
+
+        @Setup(Level.Iteration)
+        public void clean() {
+            this.processed = this.processFailed = 0;
+        }
+    }
+
+    @AuxCounters
+    @State(Scope.Thread)
+    public static class CallerCounters {
+        public long callsFailed;
+
+        @Setup(Level.Iteration)
+        public void clean() {
+            this.callsFailed = 0;
+        }
+    }
+
+    public static final class StoppedException extends RuntimeException {
+
+    }
+
+    private static final StoppedException STOPPED = new StoppedException();
+
+    private static final class MyWaitStrategy
+            implements org.jctools.channels.spsc.SpscOffHeapFixedSizeWithReferenceSupportRingBuffer.WaitStrategy {
+        public Control control;
+        private int retries;
+
+        @Override
+        public int idle(final int idleCounter) {
+            if (this.control.stopMeasurement) {
+                throw STOPPED;
+            }
+            this.retries = idleCounter;
+            return idleCounter + 1;
+        }
+
+    }
+
+    private ProxyChannel<BenchIFace> channel;
+    private BenchIFace proxy;
+    private BenchIFace impl;
+    private MyWaitStrategy waitStrategy;
+
+    int intArg;
+    Object objArg;
+    long longArg;
+    long longArg2;
+    long longArg3;
+    long longArg4;
+    CustomType customType0;
+    CustomType customType1;
+    CustomType customType2;
+    CustomType customType3;
+    double doubleArg;
+    double doubleArg2;
+    double doubleArg3;
+    double doubleArg4;
+    float floatArg;
+    boolean booleanArg;
+
+    @Param({ "1", "" + CAPACITY })
+    private int limit;
+
+    @Setup(Level.Iteration)
+    public void setupTrial() {
+        this.waitStrategy = new MyWaitStrategy();
+        this.channel = ProxyChannelFactory.createSpscProxy(CAPACITY, BenchIFace.class, this.waitStrategy);
+        this.proxy = this.channel.proxy();
+        this.impl = new BenchImpl(0);
+
+        this.intArg = 7;
+        this.objArg = new Object();
+        this.longArg = System.nanoTime();
+        this.longArg2 = System.nanoTime();
+        this.longArg3 = System.nanoTime();
+        this.longArg4 = System.nanoTime();
+        this.customType0 = new CustomType();
+        this.customType1 = new CustomType();
+        this.customType2 = new CustomType();
+        this.customType3 = new CustomType();
+        this.doubleArg = System.nanoTime();
+        this.doubleArg2 = System.nanoTime();
+        this.doubleArg3 = System.nanoTime();
+        this.doubleArg4 = System.nanoTime();
+        this.floatArg = 8.165f;
+        this.booleanArg = true;
+    }
+
+    @Benchmark
+    public int oneObjectArgBaseline() {
+        this.impl.oneObjectArg(this.objArg);
+        return this.waitStrategy.retries;
+    }
+
+    @Benchmark
+    @Group("oneObjectArg")
+    @GroupThreads(1)
+    public boolean oneObjectArgCaller(final Control control, final CallerCounters counters) {
+        this.waitStrategy.control = control;
+        try {
+            this.proxy.oneObjectArg(this.objArg);
+            counters.callsFailed = this.waitStrategy.retries;
+            return true;
+        } catch (final StoppedException e) {
+            return false;
+        }
+    }
+
+    @Benchmark
+    @Group("oneObjectArg")
+    @GroupThreads(1)
+    public int oneObjectArgProcessor(final ProcessorCounters counters) {
+        return doProcess(counters);
+    }
+
+    @Benchmark
+    public int oneReferenceArgBaseline() {
+        this.impl.oneReferenceArg(this.customType0);
+        return this.waitStrategy.retries;
+    }
+
+    @Benchmark
+    @Group("oneReferenceArg")
+    @GroupThreads(1)
+    public boolean oneReferenceArgCaller(final Control control, final CallerCounters counters) {
+        this.waitStrategy.control = control;
+        try {
+            this.proxy.oneReferenceArg(this.customType0);
+            counters.callsFailed = this.waitStrategy.retries;
+            return true;
+        } catch (final StoppedException e) {
+            return false;
+        }
+    }
+
+    @Benchmark
+    @Group("oneReferenceArg")
+    @GroupThreads(1)
+    public int oneReferenceArgProcessor(final ProcessorCounters counters) {
+        return doProcess(counters);
+    }
+
+    @Benchmark
+    public int twoMixedLengthPrimitiveArgsBaseline() {
+        this.impl.twoMixedLengthPrimitiveArgs(this.intArg, this.longArg);
+        return this.waitStrategy.retries;
+    }
+
+    @Benchmark
+    @Group("twoMixedLengthPrimitiveArgs")
+    @GroupThreads(1)
+    public boolean twoMixedLengthPrimitiveArgsCaller(final Control control, final CallerCounters counters) {
+        this.waitStrategy.control = control;
+        try {
+            this.proxy.twoMixedLengthPrimitiveArgs(this.intArg, this.longArg);
+            counters.callsFailed = this.waitStrategy.retries;
+            return true;
+        } catch (final StoppedException e) {
+            return false;
+        }
+    }
+
+    @Benchmark
+    @Group("twoMixedLengthPrimitiveArgs")
+    @GroupThreads(1)
+    public int twoMixedLengthPrimitiveArgsProcessor(final ProcessorCounters counters) {
+        return doProcess(counters);
+    }
+
+    @Benchmark
+    public int onePrimitiveArgBaseline() {
+        this.impl.onePrimitiveArg(this.intArg);
+        return this.waitStrategy.retries;
+    }
+
+    @Benchmark
+    @Group("onePrimitiveArg")
+    @GroupThreads(1)
+    public boolean onePrimitiveArgCaller(final Control control, final CallerCounters counters) {
+        this.waitStrategy.control = control;
+        try {
+            this.proxy.onePrimitiveArg(this.intArg);
+            counters.callsFailed = this.waitStrategy.retries;
+            return true;
+        } catch (final StoppedException e) {
+            return false;
+        }
+    }
+
+    @Benchmark
+    @Group("onePrimitiveArg")
+    @GroupThreads(1)
+    public int onePrimitiveArgProcessor(final ProcessorCounters counters) {
+        return doProcess(counters);
+    }
+
+    @Benchmark
+    public int noArgsBaseline() {
+        this.impl.noArgs();
+        return this.waitStrategy.retries;
+    }
+
+    @Benchmark
+    @Group("noArgs")
+    @GroupThreads(1)
+    public boolean noArgsCaller(final Control control, final CallerCounters counters) {
+        this.waitStrategy.control = control;
+        try {
+            this.proxy.noArgs();
+            counters.callsFailed = this.waitStrategy.retries;
+            return true;
+        } catch (final StoppedException e) {
+            return false;
+        }
+    }
+
+    @Benchmark
+    @Group("noArgs")
+    @GroupThreads(1)
+    public int noArgsProcessor(final ProcessorCounters counters) {
+        return doProcess(counters);
+    }
+
+    @Benchmark
+    public int tenMixedArgsBaseline() {
+        this.impl.tenMixedArgs(this.intArg,
+                this.objArg,
+                this.longArg,
+                this.customType0,
+                this.doubleArg,
+                this.customType1,
+                this.floatArg,
+                this.customType2,
+                this.booleanArg,
+                this.customType3);
+        return this.waitStrategy.retries;
+    }
+
+    @Benchmark
+    @Group("tenMixedArgs")
+    @GroupThreads(1)
+    public boolean tenMixedArgsCaller(final Control control, final CallerCounters counters) {
+        this.waitStrategy.control = control;
+        try {
+            this.proxy.tenMixedArgs(this.intArg,
+                    this.objArg,
+                    this.longArg,
+                    this.customType0,
+                    this.doubleArg,
+                    this.customType1,
+                    this.floatArg,
+                    this.customType2,
+                    this.booleanArg,
+                    this.customType3);
+            counters.callsFailed = this.waitStrategy.retries;
+            return true;
+        } catch (final StoppedException e) {
+            return false;
+        }
+    }
+
+    @Benchmark
+    @Group("tenMixedArgs")
+    @GroupThreads(1)
+    public int tenMixedArgsProcessor(final ProcessorCounters counters) {
+        return doProcess(counters);
+    }
+
+    @Benchmark
+    public int alignedPrimitiveArgsBaseline() {
+        this.impl.alignedPrimitiveArgs(intArg,
+                longArg,
+                doubleArg,
+                longArg2,
+                doubleArg2,
+                longArg3,
+                doubleArg3,
+                longArg4,
+                doubleArg4,
+                longArg,
+                doubleArg,
+                longArg2,
+                doubleArg2,
+                longArg3,
+                doubleArg3,
+                longArg4,
+                doubleArg4);
+        return this.waitStrategy.retries;
+    }
+
+    @Benchmark
+    @Group("alignedPrimitiveArgs")
+    @GroupThreads(1)
+    public boolean alignedPrimitiveArgsCaller(final Control control, final CallerCounters counters) {
+        this.waitStrategy.control = control;
+        try {
+            this.proxy.alignedPrimitiveArgs(intArg,
+                    longArg,
+                    doubleArg,
+                    longArg2,
+                    doubleArg2,
+                    longArg3,
+                    doubleArg3,
+                    longArg4,
+                    doubleArg4,
+                    longArg,
+                    doubleArg,
+                    longArg2,
+                    doubleArg2,
+                    longArg3,
+                    doubleArg3,
+                    longArg4,
+                    doubleArg4);
+            counters.callsFailed = this.waitStrategy.retries;
+            return true;
+        } catch (final StoppedException e) {
+            return false;
+        }
+    }
+
+    @Benchmark
+    @Group("alignedPrimitiveArgs")
+    @GroupThreads(1)
+    public int alignedPrimitiveArgsProcessor(final ProcessorCounters counters) {
+        return doProcess(counters);
+    }
+
+    @Benchmark
+    public int unalignedPrimitiveArgsBaseline() {
+        this.impl.unalignedPrimitiveArgs(
+                longArg,
+                doubleArg,
+                longArg2,
+                doubleArg2,
+                longArg3,
+                doubleArg3,
+                longArg4,
+                doubleArg4,
+                longArg,
+                doubleArg,
+                longArg2,
+                doubleArg2,
+                longArg3,
+                doubleArg3,
+                longArg4,
+                doubleArg4,
+                intArg);
+        return this.waitStrategy.retries;
+    }
+
+    @Benchmark
+    @Group("unalignedPrimitiveArgs")
+    @GroupThreads(1)
+    public boolean unalignedPrimitiveArgsCaller(final Control control, final CallerCounters counters) {
+        this.waitStrategy.control = control;
+        try {
+            this.proxy.unalignedPrimitiveArgs(
+                    longArg,
+                    doubleArg,
+                    longArg2,
+                    doubleArg2,
+                    longArg3,
+                    doubleArg3,
+                    longArg4,
+                    doubleArg4,
+                    longArg,
+                    doubleArg,
+                    longArg2,
+                    doubleArg2,
+                    longArg3,
+                    doubleArg3,
+                    longArg4,
+                    doubleArg4,
+                    intArg);
+            counters.callsFailed = this.waitStrategy.retries;
+            return true;
+        } catch (final StoppedException e) {
+            return false;
+        }
+    }
+
+    @Benchmark
+    @Group("unalignedPrimitiveArgs")
+    @GroupThreads(1)
+    public int unalignedPrimitiveArgsProcessor(final ProcessorCounters counters) {
+        return doProcess(counters);
+    }
+
+    private int doProcess(final ProcessorCounters counters) {
+        final int processed = this.channel.process(this.impl, this.limit);
+        if (processed == 0) {
+            counters.processFailed++;
+        } else {
+            counters.processed += processed;
+        }
+        return processed;
+    }
+
+    public static void main(final String[] args) throws Exception {
+//        final String logFile = SpscProxyChannelBenchmark.class.getSimpleName() + ".log";
+        final Options opt = new OptionsBuilder()
+                .include(SpscProxyChannelBenchmark.class.getSimpleName() + ".*align.*")
+                // .jvmArgsAppend("-XX:+UnlockDiagnosticVMOptions",
+                // "-XX:+TraceClassLoading",
+                // "-XX:+LogCompilation",
+                // "-XX:LogFile=" + logFile,
+                // "-XX:+PrintAssembly")
+                .warmupIterations(5)
+                .measurementIterations(5)
+                .param("limit", "1")
+                .forks(0)
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/jctools-experimental/pom.xml
+++ b/jctools-experimental/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
+            <artifactId>asm-all</artifactId>
             <version>5.1</version>
         </dependency>
     </dependencies>

--- a/jctools-experimental/pom.xml
+++ b/jctools-experimental/pom.xml
@@ -36,8 +36,8 @@
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
-            <version>5.0.4</version>
+            <artifactId>asm</artifactId>
+            <version>5.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/jctools-experimental/src/main/java/org/jctools/channels/OffHeapFixedMessageSizeRingBuffer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/OffHeapFixedMessageSizeRingBuffer.java
@@ -53,8 +53,12 @@ public abstract class OffHeapFixedMessageSizeRingBuffer {
     }
 
     public OffHeapFixedMessageSizeRingBuffer(final int capacity, final int messageSize) {
-        this(allocateAlignedByteBuffer(getRequiredBufferSize(capacity, messageSize), CACHE_LINE_SIZE), Pow2
-                .roundToPowerOfTwo(capacity), true, true, true, messageSize);
+        this(allocateAlignedByteBuffer(getRequiredBufferSize(capacity, messageSize), CACHE_LINE_SIZE), 
+                Pow2.roundToPowerOfTwo(capacity),
+                true,
+                true,
+                true,
+                messageSize);
     }
 
     /**

--- a/jctools-experimental/src/main/java/org/jctools/channels/OffHeapFixedMessageSizeWithReferenceSupportRingBuffer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/OffHeapFixedMessageSizeWithReferenceSupportRingBuffer.java
@@ -1,0 +1,74 @@
+package org.jctools.channels;
+
+import static org.jctools.util.JvmInfo.CACHE_LINE_SIZE;
+import static org.jctools.util.UnsafeDirectByteBuffer.allocateAlignedByteBuffer;
+
+import java.nio.ByteBuffer;
+
+import org.jctools.util.Pow2;
+
+public abstract class OffHeapFixedMessageSizeWithReferenceSupportRingBuffer extends OffHeapFixedMessageSizeRingBuffer {
+
+    protected final Object[] references;
+    protected final int arrayMessageSize;
+
+    /**
+     * 
+     * @param capacity in messages, actual capacity will be
+     * @param messageSize size in bytes for each message
+     * @param arrayMessageSize size in element count for each message
+     */
+    public OffHeapFixedMessageSizeWithReferenceSupportRingBuffer(final int capacity,
+            final int messageSize,
+            int arrayMessageSize) {
+        this(allocateAlignedByteBuffer(getRequiredBufferSize(capacity, messageSize), CACHE_LINE_SIZE),
+                Pow2.roundToPowerOfTwo(capacity),
+                true,
+                true,
+                true,
+                messageSize,
+                createReferenceArray(capacity, arrayMessageSize),
+                arrayMessageSize);
+    }
+
+    protected static Object[] createReferenceArray(final int capacity, int arrayMessageSize) {
+        return new Object[getRequiredArraySize(capacity, arrayMessageSize)];
+    }
+
+    public OffHeapFixedMessageSizeWithReferenceSupportRingBuffer(ByteBuffer buff,
+            int capacity,
+            boolean isProducer,
+            boolean isConsumer,
+            boolean initialize,
+            int messageSize,
+            Object[] references,
+            int arrayMessageSize) {
+        super(buff, capacity, isProducer, isConsumer, initialize, messageSize);
+        this.references = references;
+        this.arrayMessageSize = arrayMessageSize;
+    }
+
+    public static int getRequiredArraySize(final int capacity, final int messageSize) {
+        return Pow2.roundToPowerOfTwo(capacity) * messageSize;
+    }
+
+    protected final long arrayIndexForCursor(long currentHead) {
+        return arrayIndexForCursor(mask, arrayMessageSize, currentHead);
+    }
+
+    protected static long arrayIndexForCursor(long mask,
+            int arrayMessageSize,
+            long currentHead) {
+        return (currentHead & mask) * arrayMessageSize;
+    }
+
+    protected long consumerReferenceArrayIndex() {
+        final long consumerIndex = lpConsumerIndex();
+        return arrayIndexForCursor(consumerIndex);
+    }
+    
+    protected long producerReferenceArrayIndex() {
+        final long producerIndex = lpProducerIndex();
+        return arrayIndexForCursor(producerIndex);
+    }
+}

--- a/jctools-experimental/src/main/java/org/jctools/channels/proxy/LocalsHelper.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/proxy/LocalsHelper.java
@@ -1,0 +1,48 @@
+package org.jctools.channels.proxy;
+
+import static java.lang.System.out;
+
+import org.objectweb.asm.Type;
+
+public final class LocalsHelper {
+    private int nextLocalIndex = 0;
+
+    private LocalsHelper() {
+    };
+
+    public int newLocal(Class<?> cls) {
+        Type type = Type.getType(cls);
+        return newLocal(type);
+    }
+    
+
+    private int newLocal(Type type) {
+        final int myIndex = nextLocalIndex;
+        nextLocalIndex += type.getSize();
+        return myIndex;
+    }
+
+    public static LocalsHelper forStaticMethod() {
+        return new LocalsHelper();
+    }
+
+    public static LocalsHelper forInstanceMethod() {
+        LocalsHelper helper = new LocalsHelper();
+        helper.newLocal(Object.class);
+        return helper;
+    }
+
+    public static void main(String[] args) throws Exception {
+        LocalsHelper helper =
+                LocalsHelper.forInstanceMethod();
+        out.println(helper.newLocal(int.class));
+        out.println(helper.newLocal(int.class));
+        out.println(helper.newLocal(long.class));
+        out.println(helper.newLocal(double.class));
+        out.println(helper.newLocal(boolean.class));
+        out.println(helper.newLocal(Object.class));
+        out.println(helper.newLocal(Object.class));
+        out.println(helper.newLocal(Object.class));
+        out.println();
+    }
+}

--- a/jctools-experimental/src/main/java/org/jctools/channels/proxy/ProxyChannelFactory.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/proxy/ProxyChannelFactory.java
@@ -1,9 +1,424 @@
 package org.jctools.channels.proxy;
 
+import org.jctools.channels.spsc.SpscOffHeapFixedSizeRingBuffer;
+import org.jctools.util.UnsafeAccess;
+import org.objectweb.asm.*;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
 public class ProxyChannelFactory {
 
-    static <E> ProxyChannel<E> createSpscProxy(int size) {
-        // code gen magic goes here!
-        return null;
+    static <E> ProxyChannel<E> createSpscProxy(int capacity, Class<E> iFace) {
+
+        if (!iFace.isInterface()) {
+            throw new IllegalArgumentException("Not an interface: " + iFace);
+        }
+
+        String generatedName = Type.getInternalName(iFace) + "$JCTools$ProxyChannel";
+
+        Class<?> preExisting = findExisting(generatedName, iFace);
+        if (preExisting != null) {
+            return instantiate(preExisting, capacity);
+        }
+
+        ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+
+        classWriter.visit(Opcodes.V1_4,
+                Opcodes.ACC_SYNTHETIC | Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
+                generatedName,
+                null,
+                Type.getInternalName(SpscOffHeapFixedSizeRingBuffer.class),
+                new String[]{Type.getInternalName(ProxyChannel.class), Type.getInternalName(iFace)});
+
+        implementConstructor(classWriter);
+
+        implementProxyInstance(classWriter, iFace, generatedName);
+        implementProxy(classWriter, iFace, generatedName);
+
+        Method[] methods = iFace.getMethods();
+
+        int type = 1;
+        List<Method> relevantMethods = new ArrayList<Method>(methods.length);
+        for (Method method : methods) {
+            if (Modifier.isAbstract(method.getModifiers())) {
+                relevantMethods.add(method);
+                implementUserMethod(method, classWriter, type++);
+            }
+        }
+
+        if (relevantMethods.isEmpty()) {
+            throw new IllegalArgumentException("Does not declare any abstract methods: " + iFace);
+        }
+
+        implementProcess(classWriter, relevantMethods, iFace, generatedName);
+
+        classWriter.visitEnd();
+
+        synchronized (ProxyChannelFactory.class) {
+            preExisting = findExisting(generatedName, iFace);
+            if (preExisting != null) {
+                return instantiate(preExisting, capacity);
+            }
+            byte[] byteCode = classWriter.toByteArray();
+            // Caveat: The interface and JCTools must be on the same class loader. Maybe class loader should be an argument? Overload?
+            return instantiate(UnsafeAccess.UNSAFE.defineClass(generatedName, byteCode, 0, byteCode.length, iFace.getClassLoader(), null), capacity);
+        }
+    }
+
+    private static Class<?> findExisting(String generatedName, Class<?> iFace) {
+        try {
+            return Class.forName(generatedName, true, iFace.getClassLoader());
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E> ProxyChannel<E> instantiate(Class<?> proxy, int capacity) {
+        try {
+            return (ProxyChannel<E>) proxy.getDeclaredConstructor(int.class).newInstance(capacity);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void implementProcess(ClassVisitor classVisitor, List<Method> methods, Class<?> iFace, String generatedName) {
+
+
+        // public int process (E impl, int limit)
+        MethodVisitor methodVisitor = classVisitor.visitMethod(Opcodes.ACC_PUBLIC,
+                "process",
+                "(" + Type.getDescriptor(iFace) + "I)I",
+                null,
+                null);
+        methodVisitor.visitCode();
+
+        //int i = 0; // offset 3
+        methodVisitor.visitInsn(Opcodes.ICONST_0);
+        methodVisitor.visitVarInsn(Opcodes.ISTORE, 3);
+
+
+        // label <loopStart>;
+        Label loopStart = new Label(), loopEnd = new Label();
+        methodVisitor.visitLabel(loopStart);
+
+
+        // if (i < limit) goto <loopEnd>;
+        methodVisitor.visitVarInsn(Opcodes.ILOAD, 3);
+        methodVisitor.visitVarInsn(Opcodes.ILOAD, 2);
+        methodVisitor.visitJumpInsn(Opcodes.IF_ICMPGE, loopEnd);
+
+
+        // prepare switch labels
+        Label endOfSwitch = new Label();
+        Label[] cases = new Label[methods.size()];
+        for (int index = 0; index < cases.length; index++) {
+            cases[index] = new Label();
+        }
+
+        // long rOffset = this.readAcquire(); // offset 4
+        readAcquire(methodVisitor);
+        methodVisitor.visitVarInsn(Opcodes.LSTORE, 4);
+
+
+        // if (rOffset == EOF) goto <loopEnd>;
+        methodVisitor.visitVarInsn(Opcodes.LLOAD, 4);
+        methodVisitor.visitLdcInsn(SpscOffHeapFixedSizeRingBuffer.EOF);
+        methodVisitor.visitInsn(Opcodes.LCMP);
+        methodVisitor.visitJumpInsn(Opcodes.IFEQ, loopEnd);
+
+        // switch(UnsafeAccess.UNSAFE.getInt(rOffset)) // start with case 1, increment by 1; represents "type"
+        getUnsafe(methodVisitor, int.class, 4, 0);
+        methodVisitor.visitTableSwitchInsn(1, cases.length, endOfSwitch, cases);
+
+        // add case statement for each method
+        for (int index = 0; index < cases.length; index++) {
+
+            // case <index>:
+            methodVisitor.visitLabel(cases[index]);
+            Method method = methods.get(index);
+
+            // #PUSH: impl
+            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
+
+            // # W_OFFSET_DELTA = 4
+            // #FOREACH param in method
+            int wOffsetDelta = 4;
+            for (Class<?> parameterType : method.getParameterTypes()) {
+                // #PUSH: UnsafeAccess.UNSAFE.get[param.type](rOffset + #W_OFFSET_DELTA);
+                // #W_OFFSET_DELTA += if param.type in {long, double} 8 else 4;
+                getUnsafe(methodVisitor, parameterType, 4, wOffsetDelta);
+                wOffsetDelta += memorySize(parameterType);
+            }
+            // #END
+
+            // this.readRelease(rOffset);
+            readRelease(methodVisitor, 4);
+
+            // method.invoke(impl, <args>);
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE,
+                    Type.getInternalName(iFace),
+                    method.getName(),
+                    Type.getMethodDescriptor(method),
+                    true);
+
+            // break;
+            methodVisitor.visitJumpInsn(Opcodes.GOTO, endOfSwitch);
+        }
+
+        // label <endOfSwitch>;
+        methodVisitor.visitLabel(endOfSwitch);
+
+        // i++;
+        methodVisitor.visitIincInsn(3, 1);
+
+        // goto <loopStart>;
+        methodVisitor.visitJumpInsn(Opcodes.GOTO, loopStart);
+        methodVisitor.visitLabel(loopEnd);
+
+        // return i;
+        methodVisitor.visitVarInsn(Opcodes.ILOAD, 3);
+        methodVisitor.visitInsn(Opcodes.IRETURN);
+
+        // size requirement is computed by ASM; complete method.
+        methodVisitor.visitMaxs(-1, -1);
+        methodVisitor.visitEnd();
+
+        // Add generic bridge method for erasure public int process (Object impl, int limit)
+        methodVisitor = classVisitor.visitMethod(Opcodes.ACC_BRIDGE | Opcodes.ACC_SYNTHETIC | Opcodes.ACC_PUBLIC,
+                "process",
+                "(" + Type.getDescriptor(Object.class) + "I)I",
+                null,
+                null);
+        methodVisitor.visitCode();
+
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
+        methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(iFace));
+        methodVisitor.visitVarInsn(Opcodes.ILOAD, 2);
+
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                generatedName,
+                "process",
+                "(" + Type.getDescriptor(iFace) + "I)I",
+                false);
+
+        methodVisitor.visitInsn(Opcodes.IRETURN);
+
+        methodVisitor.visitMaxs(-1, -1);
+        methodVisitor.visitEnd();
+    }
+
+    private static void implementConstructor(ClassVisitor classVisitor) {
+        MethodVisitor methodVisitor = classVisitor.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(I)V", null, null);
+        methodVisitor.visitCode();
+
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+        methodVisitor.visitVarInsn(Opcodes.ILOAD, 1);
+        methodVisitor.visitIntInsn(Opcodes.BIPUSH, 13);
+
+        methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL,
+                Type.getInternalName(SpscOffHeapFixedSizeRingBuffer.class),
+                "<init>",
+                "(II)V",
+                false);
+
+        methodVisitor.visitInsn(Opcodes.RETURN);
+
+        methodVisitor.visitMaxs(-1, -1);
+        methodVisitor.visitEnd();
+    }
+
+    private static void implementProxyInstance(ClassVisitor classVisitor, Class<?> iFace, String generatedName) {
+        MethodVisitor methodVisitor = classVisitor.visitMethod(Opcodes.ACC_PUBLIC,
+                "proxyInstance",
+                "(" + Type.getDescriptor(iFace) + ")" + Type.getDescriptor(iFace),
+                null,
+                null);
+        methodVisitor.visitCode();
+
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+        methodVisitor.visitInsn(Opcodes.ARETURN);
+
+        methodVisitor.visitMaxs(-1, -1);
+        methodVisitor.visitEnd();
+
+        methodVisitor = classVisitor.visitMethod(Opcodes.ACC_BRIDGE | Opcodes.ACC_SYNTHETIC | Opcodes.ACC_PUBLIC,
+                "proxyInstance",
+                "(" + Type.getDescriptor(Object.class) + ")" + Type.getDescriptor(Object.class),
+                null,
+                null);
+
+        methodVisitor.visitCode();
+
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
+        methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(iFace));
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, generatedName, "proxyInstance", "(" + Type.getDescriptor(iFace) + ")" + Type.getDescriptor(iFace), false);
+        methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(iFace));
+        methodVisitor.visitInsn(Opcodes.ARETURN);
+
+        methodVisitor.visitMaxs(-1, -1);
+        methodVisitor.visitEnd();
+    }
+
+    private static void implementProxy(ClassVisitor classVisitor, Class<?> iFace, String generatedName) {
+        MethodVisitor methodVisitor = classVisitor.visitMethod(Opcodes.ACC_PUBLIC,
+                "proxy",
+                "()" + Type.getDescriptor(iFace),
+                null,
+                null);
+
+        methodVisitor.visitCode();
+
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+        methodVisitor.visitInsn(Opcodes.ARETURN);
+
+        methodVisitor.visitMaxs(-1, -1);
+        methodVisitor.visitEnd();
+
+        methodVisitor = classVisitor.visitMethod(Opcodes.ACC_BRIDGE | Opcodes.ACC_SYNTHETIC | Opcodes.ACC_PUBLIC,
+                "proxy",
+                "()" + Type.getDescriptor(Object.class),
+                null,
+                null);
+
+        methodVisitor.visitCode();
+
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, generatedName, "proxy", "()" + Type.getDescriptor(iFace), false);
+        methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(iFace));
+        methodVisitor.visitInsn(Opcodes.ARETURN);
+
+        methodVisitor.visitMaxs(-1, -1);
+        methodVisitor.visitEnd();
+    }
+
+    private static void implementUserMethod(Method method, ClassVisitor classVisitor, int type) {
+
+        if (method.getReturnType() != void.class) {
+            throw new IllegalArgumentException("Method does not return void: " + method);
+        }
+
+        String[] exceptions = new String[method.getExceptionTypes().length];
+        int index = 0;
+        for (Class<?> exceptionType : method.getExceptionTypes()) {
+            exceptions[index++] = Type.getInternalName(exceptionType);
+        }
+
+        // @Override public void <user interface method>
+        MethodVisitor methodVisitor = classVisitor.visitMethod(Opcodes.ACC_PUBLIC,
+                method.getName(),
+                Type.getMethodDescriptor(method),
+                null,
+                exceptions.length == 0 ? null : exceptions);
+
+        methodVisitor.visitCode();
+
+        // Compute space that is occupied by this and method arguments to find offset for wOffset variable
+        int wOffset = 1;
+        for (Class<?> parameterType : method.getParameterTypes()) {
+            wOffset += Type.getType(parameterType).getSize();
+        }
+
+        // long wOffset = this.writeAcquire();
+        writeAcquire(methodVisitor);
+        methodVisitor.visitVarInsn(Opcodes.LSTORE, wOffset);
+
+        // #W_OFFSET_DELTA = 4
+        // #ARGUMENT = 1 // not zero based (zero references "this")
+        // #FOREACH param in method
+        int wOffsetDelta = 4, varOffset = 1;
+        for (Class<?> parameterType : method.getParameterTypes()) {
+            // UnsafeAccess.UNSAFE.put[param.type](wOffset + #W_OFFSET_DELTA, #ARGUMENT);
+            // #W_OFFSET_DELTA += if param.type in {long, double} 8 else 4;
+            varOffset += putUnsafe(methodVisitor, parameterType, wOffset, wOffsetDelta, varOffset);
+            wOffsetDelta += memorySize(parameterType);
+        }
+        // #END
+
+        // this.writeRelease(wOffset, #TYPE);
+        writeRelease(methodVisitor, wOffset, type);
+
+        // return;
+        methodVisitor.visitInsn(Opcodes.RETURN);
+
+        // complete method, ASM computes size requirement.
+        methodVisitor.visitMaxs(-1, -1);
+        methodVisitor.visitEnd();
+    }
+
+    private static void writeAcquire(MethodVisitor methodVisitor) {
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(SpscOffHeapFixedSizeRingBuffer.class), "writeAcquire", "()J", false);
+    }
+
+    private static void writeRelease(MethodVisitor methodVisitor, int wOffset, int type) {
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+        methodVisitor.visitVarInsn(Opcodes.LLOAD, wOffset);
+        methodVisitor.visitLdcInsn(type);
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(SpscOffHeapFixedSizeRingBuffer.class), "writeRelease", "(JI)V", false);
+    }
+
+    private static void readAcquire(MethodVisitor methodVisitor) {
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(SpscOffHeapFixedSizeRingBuffer.class), "readAcquire", "()J", false);
+    }
+
+    private static void readRelease(MethodVisitor methodVisitor, int wOffset) {
+        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+        methodVisitor.visitVarInsn(Opcodes.LLOAD, wOffset);
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(SpscOffHeapFixedSizeRingBuffer.class), "readRelease", "(J)V", false);
+    }
+
+    private static int getUnsafe(MethodVisitor methodVisitor, Class<?> parameterType, int wOffset, int wOffsetDelta) {
+        loadUnsafe(methodVisitor);
+        loadWOffset(methodVisitor, parameterType, wOffset, wOffsetDelta);
+        return parameterTypeUnsafe(methodVisitor, parameterType, false);
+    }
+
+    private static int putUnsafe(MethodVisitor methodVisitor, Class<?> parameterType, int wOffset, int wOffsetDelta, int varOffset) {
+        loadUnsafe(methodVisitor);
+        loadWOffset(methodVisitor, parameterType, wOffset, wOffsetDelta);
+        methodVisitor.visitVarInsn(Type.getType(parameterType).getOpcode(Opcodes.ILOAD), varOffset);
+        return parameterTypeUnsafe(methodVisitor, parameterType, true);
+    }
+
+    private static void loadUnsafe(MethodVisitor methodVisitor) {
+        methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, Type.getInternalName(UnsafeAccess.class), "UNSAFE", "L" + Type.getInternalName(Unsafe.class) + ";");
+    }
+
+    private static void loadWOffset(MethodVisitor methodVisitor, Class<?> parameterType, int baseOffset, long wOffsetDelta) {
+        if (parameterType == boolean.class) {
+            methodVisitor.visitInsn(Opcodes.ACONST_NULL);
+        }
+        methodVisitor.visitVarInsn(Opcodes.LLOAD, baseOffset);
+        if (wOffsetDelta != 0) {
+            methodVisitor.visitLdcInsn(wOffsetDelta);
+            methodVisitor.visitInsn(Opcodes.LADD);
+        }
+    }
+
+    private static int parameterTypeUnsafe(MethodVisitor methodVisitor, Class<?> parameterType, boolean write) {
+        parameterType = parameterType.isPrimitive() ? parameterType : Object.class;
+        Type type = Type.getType(parameterType);
+        String boolDescriptor = parameterType == boolean.class ? "Ljava/lang/Object;" : "";
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                Type.getInternalName(Unsafe.class),
+                (write ? "put" : "get") + Character.toUpperCase(type.getClassName().charAt(0)) + type.getClassName().substring(1),
+                write ? ("(" + boolDescriptor + "J" + type.getDescriptor() + ")V") : ("(" + boolDescriptor + "J)" + type.getDescriptor()),
+                false);
+        return type.getSize();
+    }
+
+    private static int memorySize(Class<?> type) {
+        if (!type.isPrimitive()) {
+            throw new IllegalArgumentException("Cannot handle non-primtive parameter type: " + type); // TODO: Add handling for reference parameters.
+        }
+        return type == long.class || type == double.class ? 8 : 4;
     }
 }

--- a/jctools-experimental/src/main/java/org/jctools/channels/spsc/SpscOffHeapFixedSizeWithReferenceSupportRingBuffer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/spsc/SpscOffHeapFixedSizeWithReferenceSupportRingBuffer.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 
 import org.jctools.channels.OffHeapFixedMessageSizeWithReferenceSupportRingBuffer;
 import org.jctools.util.Pow2;
+import org.jctools.util.UnsafeRefArrayAccess;
 
 public class SpscOffHeapFixedSizeWithReferenceSupportRingBuffer extends OffHeapFixedMessageSizeWithReferenceSupportRingBuffer {
 
@@ -38,7 +39,7 @@ public class SpscOffHeapFixedSizeWithReferenceSupportRingBuffer extends OffHeapF
 
     public SpscOffHeapFixedSizeWithReferenceSupportRingBuffer(final int capacity,
             final int messageSize,
-            int arrayMessageSize) {
+            final int arrayMessageSize) {
         this(allocateAlignedByteBuffer(getRequiredBufferSize(capacity, messageSize), CACHE_LINE_SIZE),
                 Pow2.roundToPowerOfTwo(capacity),
                 true,
@@ -105,6 +106,18 @@ public class SpscOffHeapFixedSizeWithReferenceSupportRingBuffer extends OffHeapF
         return producerOffset;
     }
 
+    protected final void writeReference(long offset, Object reference) {
+        // Is there a way to compute the element offset once and just
+        // arithmetic?
+        UnsafeRefArrayAccess.spElement(references, UnsafeRefArrayAccess.calcElementOffset(offset), reference);
+    }
+
+    protected final Object readReference(long offset) {
+        // Is there a way to compute the element offset once and just
+        // arithmetic?
+        return UnsafeRefArrayAccess.lpElement(references, UnsafeRefArrayAccess.calcElementOffset(offset));
+    }
+    
     @Override
     protected final void writeRelease(long offset) {
         writeReleaseState(offset);

--- a/jctools-experimental/src/main/java/org/jctools/channels/spsc/SpscOffHeapFixedSizeWithReferenceSupportRingBuffer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/spsc/SpscOffHeapFixedSizeWithReferenceSupportRingBuffer.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.channels.spsc;
+
+import static org.jctools.util.JvmInfo.CACHE_LINE_SIZE;
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+import static org.jctools.util.UnsafeDirectByteBuffer.allocateAlignedByteBuffer;
+
+import java.nio.ByteBuffer;
+
+import org.jctools.channels.OffHeapFixedMessageSizeWithReferenceSupportRingBuffer;
+import org.jctools.util.Pow2;
+
+public class SpscOffHeapFixedSizeWithReferenceSupportRingBuffer extends OffHeapFixedMessageSizeWithReferenceSupportRingBuffer {
+
+    private static final Integer MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step",
+            4096);
+
+    public static final long EOF = 0;
+
+    private final int lookAheadStep;
+    private final long producerLookAheadCacheAddress;
+
+    public static int getLookaheadStep(final int capacity) {
+        return Math.min(capacity / 4, MAX_LOOK_AHEAD_STEP);
+    }
+
+    public SpscOffHeapFixedSizeWithReferenceSupportRingBuffer(final int capacity,
+            final int messageSize,
+            int arrayMessageSize) {
+        this(allocateAlignedByteBuffer(getRequiredBufferSize(capacity, messageSize), CACHE_LINE_SIZE),
+                Pow2.roundToPowerOfTwo(capacity),
+                true,
+                true,
+                true,
+                messageSize,
+                createReferenceArray(capacity, arrayMessageSize),
+                arrayMessageSize);
+    }
+
+    /**
+     * This is to be used for an IPC queue with the direct buffer used being a memory mapped file.
+     *
+     * @param buff
+     * @param capacity in messages, actual capacity will be
+     * @param messageSize size in bytes for each message
+     * @param arrayMessageSize size in element count for each message
+     * 
+     */
+    protected SpscOffHeapFixedSizeWithReferenceSupportRingBuffer(final ByteBuffer buff,
+            final int capacity,
+            final boolean isProducer,
+            final boolean isConsumer,
+            final boolean initialize,
+            final int messageSize,
+            Object[] references,
+            int arrayMessageSize) {
+        super(buff, capacity, isProducer, isConsumer, initialize, messageSize, references, arrayMessageSize);
+
+        this.lookAheadStep = getLookaheadStep(capacity);
+        // Layout of the RingBuffer (assuming 64b cache line):
+        // consumerIndex(8b), pad(56b) |
+        // pad(64b) |
+        // producerIndex(8b), producerLookAheadCache(8b), pad(48b) |
+        // pad(64b) |
+        // buffer (capacity * messageSize)
+        this.producerLookAheadCacheAddress = this.producerIndexAddress + 8;
+
+        // producer owns tail and headCache
+        if (isProducer && initialize) {
+            spLookAheadCache(0);
+        }
+    }
+
+    @Override
+    protected final long writeAcquire() {
+        final long producerIndex = lpProducerIndex();
+        final long producerLookAhead = lpLookAheadCache();
+        final long producerOffset = offsetForIndex(bufferAddress, mask, messageSize, producerIndex);
+        // verify next lookAheadStep messages are clear to write
+        if (producerIndex >= producerLookAhead) {
+            final long nextLookAhead = producerIndex + lookAheadStep;
+            if (isReadReleased(offsetForIndex(nextLookAhead))) {
+                spLookAheadCache(nextLookAhead);
+            }
+            // OK, can't look ahead, but maybe just next item is ready?
+            else if (!isReadReleased(producerOffset)) {
+                return EOF;
+            }
+        }
+        soProducerIndex(producerIndex + 1); // StoreStore
+//        writeAcquireState(producerOffset);
+        // return offset for current producer index
+        return producerOffset;
+    }
+
+    @Override
+    protected final void writeRelease(long offset) {
+        writeReleaseState(offset);
+    }
+
+    protected final void writeRelease(long offset, int type) {
+        assert type != 0;
+        UNSAFE.putOrderedInt(null, offset, type);
+    }
+
+    @Override
+    protected final long readAcquire() {
+        final long consumerIndex = lpConsumerIndex();
+        final long consumerOffset = offsetForIndex(consumerIndex);
+        if (isReadReleased(consumerOffset)) {
+            return EOF;
+        }
+        soConsumerIndex(consumerIndex + 1); // StoreStore
+//        readAcquireState(consumerOffset);
+        return consumerOffset;
+    }
+
+    @Override
+    protected final void readRelease(long offset) {
+        readReleaseState(offset);
+
+    }
+
+    private long lpLookAheadCache() {
+        return UNSAFE.getLong(null, producerLookAheadCacheAddress);
+    }
+
+    private void spLookAheadCache(final long value) {
+        UNSAFE.putLong(producerLookAheadCacheAddress, value);
+    }
+}

--- a/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoIFace.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoIFace.java
@@ -7,4 +7,8 @@ public interface DemoIFace {
     void call2(float x, double y, boolean z);
 
     void call3();
+
+    void call4(Object x, Object y);
+
+    void call5(Object x, int y, Object z);
 }

--- a/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoIFace.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoIFace.java
@@ -1,6 +1,10 @@
 package org.jctools.channels.proxy;
 
 public interface DemoIFace {
+    
+    public static class CustomType {
+        
+    }
 
     void call1(int x, int y);
 
@@ -8,7 +12,9 @@ public interface DemoIFace {
 
     void call3();
 
-    void call4(Object x, Object y);
+    void call4(Object x, CustomType y);
 
-    void call5(Object x, int y, Object z);
+    void call5(CustomType x, int y, CustomType z);
+
+    void call6(int x, CustomType[] y, CustomType... z);
 }

--- a/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoIFace.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoIFace.java
@@ -1,7 +1,10 @@
 package org.jctools.channels.proxy;
 
-public interface Demo1 {
+public interface DemoIFace {
+
     void call1(int x, int y);
+
     void call2(float x, double y, boolean z);
+
     void call3();
 }

--- a/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoProxyResult.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoProxyResult.java
@@ -7,27 +7,41 @@ import org.jctools.util.UnsafeAccess;
  * Generated code. This is a mockup for methods passing primitives only.
  *
  * @author yak
- *
  */
-public class DemoProxyResult extends SpscOffHeapFixedSizeRingBuffer implements ProxyChannel<Demo1>, Demo1 {
+public class DemoProxyResult extends SpscOffHeapFixedSizeRingBuffer implements ProxyChannel<DemoIFace>, DemoIFace {
 
     public DemoProxyResult(int capacity) {
         super(capacity, 13);
     }
 
     @Override
-    public Demo1 proxyInstance(Demo1 impl) {
-        // need to construct a friend class which is very similar, and support passing objects.
-        return null;
+    public DemoIFace proxyInstance(DemoIFace impl) {
+        return new DemoIFace() {
+
+            @Override
+            public void call1(int x, int y) {
+                // TODO: What to do here?
+            }
+
+            @Override
+            public void call2(float x, double y, boolean z) {
+                // TODO: What to do here?
+            }
+
+            @Override
+            public void call3() {
+                // TODO: What to do here?
+            }
+        };
     }
 
     @Override
-    public Demo1 proxy() {
+    public DemoIFace proxy() {
         return this;
     }
 
     @Override
-    public int process(Demo1 impl, int limit) {
+    public int process(DemoIFace impl, int limit) {
         int i = 0;
         for (; i < limit; i++) {
             long rOffset = this.readAcquire();
@@ -38,26 +52,26 @@ public class DemoProxyResult extends SpscOffHeapFixedSizeRingBuffer implements P
             // Start off with a switch and see how we do. The compiler *should* be able to convert a large switch
             // to a lookup table and *should* be better equipped to make the call.
             switch (type) {
-            case 1: {
-                int x = UnsafeAccess.UNSAFE.getInt(rOffset + 4);
-                int y = UnsafeAccess.UNSAFE.getInt(rOffset + 8);
-                this.readRelease(rOffset);
-                impl.call1(x, y);
-                break;
-            }
-            case 2: {
-                float x = UnsafeAccess.UNSAFE.getFloat(rOffset + 4);
-                double y = UnsafeAccess.UNSAFE.getDouble(rOffset + 8);
-                boolean z = UnsafeAccess.UNSAFE.getBoolean(null, rOffset + 16);
-                this.readRelease(rOffset);
-                impl.call2(x, y, z);
-                break;
-            }
-            case 3: {
-                this.readRelease(rOffset);
-                impl.call3();
-                break;
-            }
+                case 1: {
+                    int x = UnsafeAccess.UNSAFE.getInt(rOffset + 4);
+                    int y = UnsafeAccess.UNSAFE.getInt(rOffset + 8);
+                    this.readRelease(rOffset);
+                    impl.call1(x, y);
+                    break;
+                }
+                case 2: {
+                    float x = UnsafeAccess.UNSAFE.getFloat(rOffset + 4);
+                    double y = UnsafeAccess.UNSAFE.getDouble(rOffset + 8);
+                    boolean z = UnsafeAccess.UNSAFE.getBoolean(null, rOffset + 16);
+                    this.readRelease(rOffset);
+                    impl.call2(x, y, z);
+                    break;
+                }
+                case 3: {
+                    this.readRelease(rOffset);
+                    impl.call3();
+                    break;
+                }
             }
         }
 
@@ -81,7 +95,7 @@ public class DemoProxyResult extends SpscOffHeapFixedSizeRingBuffer implements P
         long wOffset = this.writeAcquire();
         UnsafeAccess.UNSAFE.putFloat(wOffset + 4, x);
         UnsafeAccess.UNSAFE.putDouble(wOffset + 8, y);
-        UnsafeAccess.UNSAFE.putBoolean(null, wOffset + 8, z);
+        UnsafeAccess.UNSAFE.putBoolean(null, wOffset + 16, z);
         this.writeRelease(wOffset, 2);
     }
 

--- a/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoProxyResult.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoProxyResult.java
@@ -16,38 +16,8 @@ public class DemoProxyResult extends SpscOffHeapFixedSizeWithReferenceSupportRin
 
     @Override
     public DemoIFace proxyInstance(DemoIFace impl) {
-        return new DemoIFace() {
-
-            @Override
-            public void call1(int x, int y) {
-                // TODO: What to do here?
-            }
-
-            @Override
-            public void call2(float x, double y, boolean z) {
-                // TODO: What to do here?
-            }
-
-            @Override
-            public void call3() {
-                // TODO: What to do here?
-            }
-
-            @Override
-            public void call4(Object x, CustomType y) {
-                // TODO: What to do here?
-            }
-
-            @Override
-            public void call5(CustomType x, int y, CustomType z) {
-                // TODO: What to do here?
-            }
-
-            @Override
-            public void call6(int x, CustomType[] y, CustomType... z) {
-                // TODO: What to do here?
-            }
-        };
+        // What should we do here?
+        return this;
     }
 
     @Override

--- a/jctools-experimental/src/test/java/org/jctools/channels/proxy/ProxyCreationTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/proxy/ProxyCreationTest.java
@@ -1,0 +1,87 @@
+package org.jctools.channels.proxy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ProxyCreationTest {
+
+    @Test
+    public void testGenerated() throws Exception {
+
+        ProxyChannel<DemoIFace> proxyChannel = ProxyChannelFactory.createSpscProxy(10, DemoIFace.class);
+
+        DemoIFace proxy = proxyChannel.proxy();
+        proxy.call1(1, 2);
+        proxy.call2(1, 2L, false);
+        proxy.call3();
+
+        DemoIFace implAssertions = new DemoIFace() {
+
+            @Override
+            public void call1(int x, int y) {
+                Assert.assertEquals(1, x);
+                Assert.assertEquals(2, y);
+            }
+
+            @Override
+            public void call2(float x, double y, boolean z) {
+                Assert.assertEquals(1, x, 0.000000001);
+                Assert.assertEquals(2, y, 0.000000001);
+                Assert.assertEquals(false, z);
+            }
+
+            @Override
+            public void call3() {
+                throw new RuntimeException();
+            }
+        };
+        proxyChannel.process(implAssertions, 1);
+        proxyChannel.process(implAssertions, 1);
+        try {
+            proxyChannel.process(implAssertions, 1);
+        } catch (RuntimeException e) {
+            return;
+        }
+        Assert.fail();
+    }
+
+    @Test
+    public void testDemo() throws Exception {
+
+        ProxyChannel<DemoIFace> proxyChannel = new DemoProxyResult(10);
+
+        DemoIFace proxy = proxyChannel.proxy();
+        proxy.call1(1, 2);
+        proxy.call2(1, 2L, false);
+        proxy.call3();
+
+        DemoIFace implAssertions = new DemoIFace() {
+
+            @Override
+            public void call1(int x, int y) {
+                Assert.assertEquals(1, x);
+                Assert.assertEquals(2, y);
+            }
+
+            @Override
+            public void call2(float x, double y, boolean z) {
+                Assert.assertEquals(1, x, 0.000000001);
+                Assert.assertEquals(2, y, 0.000000001);
+                Assert.assertEquals(false, z);
+            }
+
+            @Override
+            public void call3() {
+                throw new RuntimeException();
+            }
+        };
+        proxyChannel.process(implAssertions, 1);
+        proxyChannel.process(implAssertions, 1);
+        try {
+            proxyChannel.process(implAssertions, 1);
+        } catch (RuntimeException e) {
+            return;
+        }
+        Assert.fail();
+    }
+}

--- a/jctools-experimental/src/test/java/org/jctools/channels/proxy/ProxyCreationTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/proxy/ProxyCreationTest.java
@@ -1,6 +1,8 @@
 package org.jctools.channels.proxy;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import org.jctools.channels.proxy.DemoIFace.CustomType;
@@ -17,6 +19,17 @@ public class ProxyCreationTest {
             throw new RuntimeException(MESSAGE);
         }
 
+    }
+
+    @Test
+    public void testGeneratedProxyInstance() {
+        ProxyChannel<DemoIFace> proxyChannel =
+                ProxyChannelFactory.createSpscProxy(10, DemoIFace.class, (idleCounter) -> 0);
+        DemoIFace proxy = proxyChannel.proxy();
+        /*
+         * Not sure what the proper behaviour is here but I can see from the types it should at least be a DemoIFace
+         */
+        assertThat(proxyChannel.proxyInstance(proxy), instanceOf(DemoIFace.class));
     }
 
     @Test

--- a/jctools-experimental/src/test/java/org/jctools/channels/proxy/ProxyCreationTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/proxy/ProxyCreationTest.java
@@ -1,5 +1,6 @@
 package org.jctools.channels.proxy;
 
+import org.jctools.channels.proxy.DemoIFace.CustomType;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -11,13 +12,15 @@ public class ProxyCreationTest {
         ProxyChannel<DemoIFace> proxyChannel = ProxyChannelFactory.createSpscProxy(10, DemoIFace.class);
 
         DemoIFace proxy = proxyChannel.proxy();
-        Object obj1 = new Object();
-        Object obj2 = new Object();
+        CustomType obj1 = new CustomType();
+        CustomType obj2 = new CustomType();
+        CustomType[] objArray = new CustomType[] { obj2, obj1 };
         proxy.call1(1, 2);
         proxy.call2(1, 2L, false);
         proxy.call3();
         proxy.call4(obj1, obj2);
         proxy.call5(obj1, 1, obj2);
+        proxy.call6(6, objArray, obj1, obj2);
 
         DemoIFace implAssertions = new DemoIFace() {
 
@@ -40,16 +43,23 @@ public class ProxyCreationTest {
             }
 
             @Override
-            public void call4(Object x, Object y) {
+            public void call4(Object x, CustomType y) {
                 Assert.assertSame(obj1, x);
                 Assert.assertSame(obj2, y);
             }
 
             @Override
-            public void call5(Object x, int y, Object z) {
+            public void call5(CustomType x, int y, CustomType z) {
                 Assert.assertSame(obj1, x);
                 Assert.assertEquals(1, y);
                 Assert.assertSame(obj2, z);
+            }
+
+            @Override
+            public void call6(int x, CustomType[] y, CustomType... z) {
+                Assert.assertEquals(6, x);
+                Assert.assertSame(objArray, y);
+                Assert.assertArrayEquals(new Object[] { obj1, obj2 }, z);
             }
         };
         proxyChannel.process(implAssertions, 1);
@@ -60,6 +70,7 @@ public class ProxyCreationTest {
         } catch (RuntimeException e) {
             // Happy
         }
+        proxyChannel.process(implAssertions, 1);
         proxyChannel.process(implAssertions, 1);
         proxyChannel.process(implAssertions, 1);
     }
@@ -70,13 +81,15 @@ public class ProxyCreationTest {
         ProxyChannel<DemoIFace> proxyChannel = new DemoProxyResult(10);
 
         DemoIFace proxy = proxyChannel.proxy();
-        Object obj1 = new Object();
-        Object obj2 = new Object();
+        CustomType obj1 = new CustomType();
+        CustomType obj2 = new CustomType();
+        CustomType[] objArray = new CustomType[] { obj2, obj1 };
         proxy.call1(1, 2);
         proxy.call2(1, 2L, false);
         proxy.call3();
         proxy.call4(obj1, obj2);
         proxy.call5(obj1, 1, obj2);
+        proxy.call6(6, objArray, obj1, obj2);
 
         DemoIFace implAssertions = new DemoIFace() {
 
@@ -99,16 +112,23 @@ public class ProxyCreationTest {
             }
 
             @Override
-            public void call4(Object x, Object y) {
+            public void call4(Object x, CustomType y) {
                 Assert.assertSame(obj1, x);
                 Assert.assertSame(obj2, y);
             }
 
             @Override
-            public void call5(Object x, int y, Object z) {
+            public void call5(CustomType x, int y, CustomType z) {
                 Assert.assertSame(obj1, x);
                 Assert.assertEquals(1, y);
                 Assert.assertSame(obj2, z);
+            }
+
+            @Override
+            public void call6(int x, CustomType[] y, CustomType... z) {
+                Assert.assertEquals(6, x);
+                Assert.assertSame(objArray, y);
+                Assert.assertArrayEquals(new Object[] { obj1, obj2 }, z);
             }
         };
         proxyChannel.process(implAssertions, 1);
@@ -119,6 +139,7 @@ public class ProxyCreationTest {
         } catch (RuntimeException e) {
             // Happy
         }
+        proxyChannel.process(implAssertions, 1);
         proxyChannel.process(implAssertions, 1);
         proxyChannel.process(implAssertions, 1);
     }

--- a/jctools-experimental/src/test/java/org/jctools/channels/proxy/ProxyCreationTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/proxy/ProxyCreationTest.java
@@ -4,16 +4,20 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ProxyCreationTest {
-
+    
     @Test
     public void testGenerated() throws Exception {
 
         ProxyChannel<DemoIFace> proxyChannel = ProxyChannelFactory.createSpscProxy(10, DemoIFace.class);
 
         DemoIFace proxy = proxyChannel.proxy();
+        Object obj1 = new Object();
+        Object obj2 = new Object();
         proxy.call1(1, 2);
         proxy.call2(1, 2L, false);
         proxy.call3();
+        proxy.call4(obj1, obj2);
+        proxy.call5(obj1, 1, obj2);
 
         DemoIFace implAssertions = new DemoIFace() {
 
@@ -34,15 +38,30 @@ public class ProxyCreationTest {
             public void call3() {
                 throw new RuntimeException();
             }
+
+            @Override
+            public void call4(Object x, Object y) {
+                Assert.assertSame(obj1, x);
+                Assert.assertSame(obj2, y);
+            }
+
+            @Override
+            public void call5(Object x, int y, Object z) {
+                Assert.assertSame(obj1, x);
+                Assert.assertEquals(1, y);
+                Assert.assertSame(obj2, z);
+            }
         };
         proxyChannel.process(implAssertions, 1);
         proxyChannel.process(implAssertions, 1);
         try {
             proxyChannel.process(implAssertions, 1);
+            Assert.fail();
         } catch (RuntimeException e) {
-            return;
+            // Happy
         }
-        Assert.fail();
+        proxyChannel.process(implAssertions, 1);
+        proxyChannel.process(implAssertions, 1);
     }
 
     @Test
@@ -51,9 +70,13 @@ public class ProxyCreationTest {
         ProxyChannel<DemoIFace> proxyChannel = new DemoProxyResult(10);
 
         DemoIFace proxy = proxyChannel.proxy();
+        Object obj1 = new Object();
+        Object obj2 = new Object();
         proxy.call1(1, 2);
         proxy.call2(1, 2L, false);
         proxy.call3();
+        proxy.call4(obj1, obj2);
+        proxy.call5(obj1, 1, obj2);
 
         DemoIFace implAssertions = new DemoIFace() {
 
@@ -74,14 +97,29 @@ public class ProxyCreationTest {
             public void call3() {
                 throw new RuntimeException();
             }
+
+            @Override
+            public void call4(Object x, Object y) {
+                Assert.assertSame(obj1, x);
+                Assert.assertSame(obj2, y);
+            }
+
+            @Override
+            public void call5(Object x, int y, Object z) {
+                Assert.assertSame(obj1, x);
+                Assert.assertEquals(1, y);
+                Assert.assertSame(obj2, z);
+            }
         };
         proxyChannel.process(implAssertions, 1);
         proxyChannel.process(implAssertions, 1);
         try {
             proxyChannel.process(implAssertions, 1);
+            Assert.fail();
         } catch (RuntimeException e) {
-            return;
+            // Happy
         }
-        Assert.fail();
+        proxyChannel.process(implAssertions, 1);
+        proxyChannel.process(implAssertions, 1);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.6</java.version>
+        <java.version>1.8</java.version>
         <java.test.version>1.8</java.test.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>1.6</java.version>
         <java.test.version>1.8</java.test.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
Added support for calling methods with references. I kept the original ring buffer `OffHeapFixedMessageSizeRingBuffer` separate to `OffHeapFixedMessageSizeWithReferenceSupportRingBuffer` incase this experimental feature expanded for IPC. This may be wasted effort. The generalised protocol is that each call frame gets a fixed number of bytes for primitive arguments and a fixed number of indices in the ref array for ref arguments. This is fixed to be the largest required call frame for the time being. The ordering is the same as before, i.e. from `readAcquire`/`readRelease` and `writeAcquire`/`writeRelease`. The index to the reference arguments is calculated from a plain read of the producer or consume index within the acquire/release block.

In addition to implementing reference support a few notable bugs have been fixed

- The method `org.jctools.channels.proxy.ProxyChannelFactory.findExisting(String, Class<?>)` used the generated internal class name but the code paths here use the dotted separated class name
- The `messageSize`, that is the number of bytes required to write down all the primitive arguments of a call frame, was hard coded to 13 so I've added some logic that'll calculate that

Not really a bug but I've added _something_ (`WaitStrategy`) to handle what to do when the queue is full. I've not defaulted this so users must supply the strategy. Tests give example usage. This is implemented in `org.jctools.channels.spsc.SpscOffHeapFixedSizeWithReferenceSupportRingBuffer.writeAcquireWithWaitStrategy()` which I welcome some review of.

