### PR TITLE
Multicast channel implementation

### DIFF
--- a/jctools-benchmarks/pom.xml
+++ b/jctools-benchmarks/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <jmh-core.version>1.14</jmh-core.version>
+        <java.version>1.8</java.version>
     </properties>
 
     <dependencies>

--- a/jctools-benchmarks/src/main/java/org/jctools/channels/multicast/SpOffHeapFixedMessageSizeAppenderTpt.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/channels/multicast/SpOffHeapFixedMessageSizeAppenderTpt.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jctools.util.JvmInfo;
+import org.jctools.util.UnsafeAccess;
+import org.jctools.util.UnsafeDirectByteBuffer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+public class SpOffHeapFixedMessageSizeAppenderTpt {
+
+   @Param(value = {"132000"})
+   String requestedCapacity;
+
+   @Param(value = {"8", "32"})
+   String requestedMessageSize;
+
+   private OffHeapFixedMessageSizeAppender appender;
+
+   public static void main(final String[] args) throws Exception {
+      final Options opt = new OptionsBuilder().include(SpOffHeapFixedMessageSizeAppenderTpt.class.getSimpleName()).warmupIterations(5).measurementIterations(5).forks(1).build();
+      new Runner(opt).run();
+   }
+
+   @Setup()
+   public void init() {
+      final int capacity = Integer.parseInt(requestedCapacity);
+      final int messageSize = Integer.parseInt(requestedMessageSize);
+      final int bufferSize = ChannelLayout.getRequiredBufferSize(capacity, messageSize);
+      this.appender = new OffHeapFixedMessageSizeAppender(UnsafeDirectByteBuffer.allocateAlignedByteBuffer(bufferSize, JvmInfo.CACHE_LINE_SIZE), capacity, messageSize);
+   }
+
+   @Benchmark
+   public long shout() {
+      final OffHeapFixedMessageSizeAppender appender = this.appender;
+      final long sequence = appender.writeAcquire();
+      try {
+         final long messageAddress = appender.messageOffset(sequence);
+         UnsafeAccess.UNSAFE.putLong(messageAddress, 1L);
+         return messageAddress;
+      } finally {
+         appender.writeRelease(sequence);
+      }
+   }
+
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/channels/multicast/SpOffHeapMulticastChannelRawTptBackoffNone.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/channels/multicast/SpOffHeapMulticastChannelRawTptBackoffNone.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jctools.util.JvmInfo;
+import org.jctools.util.UnsafeAccess;
+import org.jctools.util.UnsafeDirectByteBuffer;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Group)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+public class SpOffHeapMulticastChannelRawTptBackoffNone {
+
+   private static final long DELAY_PRODUCER = Long.getLong("delay.p", 0L);
+   private static final long DELAY_CONSUMER = Long.getLong("delay.c", 0L);
+   @Param(value = {"132000"})
+   String requestedCapacity;
+   @Param(value = {"8", "32"})
+   String requestedMessageSize;
+   private long ONE;
+   private long escape;
+   private OffHeapFixedMessageSizeAppender appender;
+   private OffHeapFixedMessageSizeTailer tailer;
+   private long tailerMessageCopyAddress;
+
+   public static void main(final String[] args) throws Exception {
+      final Options opt = new OptionsBuilder().include(SpOffHeapMulticastChannelRawTptBackoffNone.class.getSimpleName()).build();
+      new Runner(opt).run();
+   }
+
+   private static void lostOrEOF(OffHeapFixedMessageSizeTailer tailer,
+                                 PollCounters counters,
+                                 long listened,
+                                 long oldLost,
+                                 SpOffHeapMulticastChannelRawTptBackoffNone bench) {
+      if (listened == OffHeapFixedMessageSizeTailer.LOST) {
+         final long newLost = tailer.lost();
+         final long lost = newLost - oldLost;
+         counters.lost += lost;
+      } else if (listened == OffHeapFixedMessageSizeTailer.EOF) {
+         //EOF
+         counters.empty++;
+         bench.backoff();
+      }
+   }
+
+   @Setup()
+   public void init() {
+      this.ONE = 777;
+      final int capacity = Integer.parseInt(requestedCapacity);
+      final int messageSize = Integer.parseInt(requestedMessageSize);
+      if (messageSize < 8) {
+         throw new AssertionError("can't run with message size<8!");
+      }
+      final int bufferSize = ChannelLayout.getRequiredBufferSize(capacity, messageSize);
+      this.appender = new OffHeapFixedMessageSizeAppender(UnsafeDirectByteBuffer.allocateAlignedByteBuffer(bufferSize, JvmInfo.CACHE_LINE_SIZE), capacity, messageSize);
+      this.tailer = new OffHeapFixedMessageSizeTailer(this.appender.buffer(), capacity, messageSize);
+      this.tailerMessageCopyAddress = this.tailer.messageCopyAddress();
+   }
+
+   @Benchmark
+   @Group("tpt")
+   public long shout() {
+      final OffHeapFixedMessageSizeAppender appender = this.appender;
+      final long sequence = appender.writeAcquire();
+      try {
+         final long messageAddress = appender.messageOffset(sequence);
+         UnsafeAccess.UNSAFE.putLong(messageAddress, ONE);
+         return messageAddress;
+      } finally {
+         appender.writeRelease(sequence);
+         if (DELAY_PRODUCER != 0) {
+            Blackhole.consumeCPU(DELAY_PRODUCER);
+         }
+      }
+   }
+
+   @Benchmark
+   @Group("tpt")
+   public void listen(PollCounters counters) {
+      final long ONE = this.ONE;
+      final OffHeapFixedMessageSizeTailer tailer = this.tailer;
+      final long messageCopyAddress = this.tailerMessageCopyAddress;
+      final long oldLost = tailer.lost();
+      final long listened = tailer.readAcquire();
+      if (listened >= 0) {
+         final long readValue = UnsafeAccess.UNSAFE.getLong(messageCopyAddress);
+         tailer.readRelease(listened);
+         if (readValue != ONE) {
+            escape = readValue;
+         }
+         counters.listened++;
+      } else {
+         lostOrEOF(tailer, counters, listened, oldLost, this);
+      }
+      if (DELAY_CONSUMER != 0) {
+         Blackhole.consumeCPU(DELAY_CONSUMER);
+      }
+   }
+
+   protected void backoff() {
+
+   }
+
+   @Setup(Level.Iteration)
+   public void chase() {
+      tailer.chase();
+   }
+
+   @AuxCounters
+   @State(Scope.Thread)
+   public static class PollCounters {
+
+      public long empty;
+      public long lost;
+      public long listened;
+
+      @Setup(Level.Iteration)
+      public void clean() {
+         empty = lost = listened = 0;
+      }
+   }
+
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/channels/multicast/SpOffHeapMulticastChannelRawTptBatchBackoffNone.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/channels/multicast/SpOffHeapMulticastChannelRawTptBatchBackoffNone.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongConsumer;
+
+import org.jctools.util.JvmInfo;
+import org.jctools.util.UnsafeAccess;
+import org.jctools.util.UnsafeDirectByteBuffer;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Group)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+public class SpOffHeapMulticastChannelRawTptBatchBackoffNone {
+
+   private static final long DELAY_PRODUCER = Long.getLong("delay.p", 0L);
+   private static final long DELAY_CONSUMER = Long.getLong("delay.c", 0L);
+   @Param(value = {"132000"})
+   String requestedCapacity;
+   @Param(value = {"8", "32"})
+   String requestedMessageSize;
+   private long ONE;
+   private long escape;
+   private OffHeapFixedMessageSizeAppender appender;
+   private OffHeapFixedMessageSizeTailer tailer;
+   private LongConsumer messageConsumer;
+
+   public static void main(final String[] args) throws Exception {
+      final Options opt = new OptionsBuilder().include(SpOffHeapMulticastChannelRawTptBatchBackoffNone.class.getSimpleName()).build();
+      new Runner(opt).run();
+   }
+
+   @Setup()
+   public void init() {
+      this.ONE = 777;
+      final int capacity = Integer.parseInt(requestedCapacity);
+      final int messageSize = Integer.parseInt(requestedMessageSize);
+      if (messageSize < 8) {
+         throw new AssertionError("can't run with message size<8!");
+      }
+      final int bufferSize = ChannelLayout.getRequiredBufferSize(capacity, messageSize);
+      this.appender = new OffHeapFixedMessageSizeAppender(UnsafeDirectByteBuffer.allocateAlignedByteBuffer(bufferSize, JvmInfo.CACHE_LINE_SIZE), capacity, messageSize);
+      this.tailer = new OffHeapFixedMessageSizeTailer(this.appender.buffer(), capacity, messageSize);
+      this.messageConsumer = new LongConsumer() {
+
+         @Override
+         public void accept(long messageAddress) {
+            final long value = UnsafeAccess.UNSAFE.getLong(messageAddress);
+            if (value != ONE) {
+               escape = value;
+            }
+         }
+      };
+   }
+
+   @Benchmark
+   @Group("tpt")
+   public long shout() {
+      final OffHeapFixedMessageSizeAppender appender = this.appender;
+      final long sequence = appender.writeAcquire();
+      try {
+         final long messageAddress = appender.messageOffset(sequence);
+         UnsafeAccess.UNSAFE.putLong(messageAddress, ONE);
+         return messageAddress;
+      } finally {
+         appender.writeRelease(sequence);
+         if (DELAY_PRODUCER != 0) {
+            Blackhole.consumeCPU(DELAY_PRODUCER);
+         }
+      }
+   }
+
+   @Benchmark
+   @Group("tpt")
+   public void batchListen(PollCounters counters) {
+      final OffHeapFixedMessageSizeTailer tailer = this.tailer;
+      final int capacity = tailer.capacity();
+      final LongConsumer messageConsumer = this.messageConsumer;
+      final long oldLost = tailer.lost();
+      final int listened = tailer.read(messageConsumer, capacity);
+      final long newLost = tailer.lost();
+      final long lost = newLost - oldLost;
+      if (lost > 0) {
+         counters.lost += lost;
+      }
+      if (listened == 0) {
+         counters.empty++;
+         backoff();
+      } else {
+         counters.listened += listened;
+      }
+      if (DELAY_CONSUMER != 0) {
+         Blackhole.consumeCPU(DELAY_CONSUMER);
+      }
+   }
+
+   protected void backoff() {
+
+   }
+
+   @Setup(Level.Iteration)
+   public void chase() {
+      tailer.chase();
+   }
+
+   @AuxCounters
+   @State(Scope.Thread)
+   public static class PollCounters {
+
+      public long empty;
+      public long lost;
+      public long listened;
+
+      @Setup(Level.Iteration)
+      public void clean() {
+         empty = lost = listened = 0;
+      }
+   }
+
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/handrolled/throughput/SpMulticastChannelPerfTest.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/handrolled/throughput/SpMulticastChannelPerfTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.handrolled.throughput;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import org.jctools.queues.MessagePassingQueue;
+import org.jctools.queues.SpMulticastChannel;
+
+public class SpMulticastChannelPerfTest {
+
+   public static void main(String[] args) throws InterruptedException {
+      final int TESTS = 20;
+      final int MESSAGES = 50000000;
+      final int CONSUMERS = 1;
+      final int CAPACITY = 1 << 17;
+      final Long value = new Long(0);
+      final SpMulticastChannel<Long> channel = new SpMulticastChannel<Long>(CAPACITY);
+      final CountDownLatch started;
+      if (CONSUMERS > 0) {
+         started = new CountDownLatch(CONSUMERS);
+      } else {
+         started = null;
+      }
+      final Thread[] listenerRunners = new Thread[CONSUMERS];
+      final SpMulticastChannel.Listener<Long>[] listeners = new SpMulticastChannel.Listener[CONSUMERS];
+      for (int i = 0; i < CONSUMERS; i++) {
+         final int consumerId = i + 1;
+         final SpMulticastChannel.Listener<Long> chaser = channel.newListener();
+         listeners[i] = chaser;
+         final Thread listenerRunner = new Thread(new Runnable() {
+            @Override
+            public void run() {
+               final SpMulticastChannel.Listener<Long> listener = chaser;
+               final MessagePassingQueue.Consumer<Long> consumer = new MessagePassingQueue.Consumer<Long>() {
+                  @Override
+                  public void accept(Long e) {
+                     if (e == null)
+                        throw new IllegalStateException("WTF!");
+                  }
+               };
+               long count = 0;
+               long isEmpty = 0;
+               started.countDown();
+               while (!Thread.currentThread().isInterrupted()) {
+                  final long oldLost = listener.lost();
+                  final long listened = listener.listen(consumer, CAPACITY);
+                  if (listened == 0 && listener.lost() == oldLost) {
+                     isEmpty++;
+                     LockSupport.parkNanos(1L);
+                  }
+                  count += listened;
+               }
+               System.out.println("[" + consumerId + "] polled: " + count + " total lost: " + listener.lost() + " empty: " + isEmpty);
+            }
+         });
+         listenerRunner.start();
+         listenerRunners[i] = listenerRunner;
+      }
+      final long[] lost = new long[CONSUMERS];
+      if (CONSUMERS > 0) {
+         started.await();
+      }
+      for (int i = 0; i < TESTS; i++) {
+
+         for (int l = 0; l < CONSUMERS; l++) {
+            lost[l] = listeners[l].lost();
+         }
+         final long start = System.nanoTime();
+         for (int m = 0; m < MESSAGES; m++) {
+            channel.shout(value);
+         }
+         final long elapsed = System.nanoTime() - start;
+         System.out.println((MESSAGES * 1000000000L) / elapsed + " msg/sec");
+         TimeUnit.SECONDS.sleep(2);
+         for (int l = 0; l < CONSUMERS; l++) {
+            System.out.println("lost msgs [" + (l + 1) + "]: " + (listeners[l].lost() - lost[l]));
+
+         }
+      }
+      for (Thread listenerRunner : listenerRunners) {
+         listenerRunner.interrupt();
+         listenerRunner.join();
+      }
+   }
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/handrolled/throughput/SpMulticastLongChannelPerfTest.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/handrolled/throughput/SpMulticastLongChannelPerfTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.handrolled.throughput;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import org.jctools.queues.SpMulticastLongChannel;
+
+public class SpMulticastLongChannelPerfTest {
+
+   public static void main(String[] args) throws InterruptedException {
+      final int TESTS = 20;
+      final int MESSAGES = 50000000;
+      final int CONSUMERS = 1;
+      final int CAPACITY = 1 << 17;
+      final SpMulticastLongChannel channel = new SpMulticastLongChannel(CAPACITY);
+      final CountDownLatch started;
+      if (CONSUMERS > 0) {
+         started = new CountDownLatch(CONSUMERS);
+      } else {
+         started = null;
+      }
+      final Thread[] listenerRunners = new Thread[CONSUMERS];
+      final SpMulticastLongChannel.Listener[] listeners = new SpMulticastLongChannel.Listener[CONSUMERS];
+      for (int i = 0; i < CONSUMERS; i++) {
+         final int consumerId = i + 1;
+         final SpMulticastLongChannel.Listener chaser = channel.newListener();
+         listeners[i] = chaser;
+         final Thread listenerRunner = new Thread(new Runnable() {
+            @Override
+            public void run() {
+               final SpMulticastLongChannel.Listener listener = chaser;
+               final SpMulticastLongChannel.Listener.LongConsumer consumer = new SpMulticastLongChannel.Listener.LongConsumer() {
+                  @Override
+                  public void accept(long value) {
+                     if (value != 1L)
+                        throw new IllegalStateException("WTF!");
+                  }
+               };
+               long count = 0;
+               long isEmpty = 0;
+               started.countDown();
+               while (!Thread.currentThread().isInterrupted()) {
+                  final long oldLost = listener.lost();
+                  final long listened = listener.listen(consumer, CAPACITY);
+                  if (listened == 0 && listener.lost() == oldLost) {
+                     isEmpty++;
+                     LockSupport.parkNanos(1L);
+                  }
+                  count += listened;
+               }
+               System.out.println("[" + consumerId + "] polled: " + count + " total lost: " + listener.lost() + " empty: " + isEmpty);
+            }
+         });
+         listenerRunner.start();
+         listenerRunners[i] = listenerRunner;
+      }
+      final long[] lost = new long[CONSUMERS];
+      if (CONSUMERS > 0) {
+         started.await();
+      }
+      for (int i = 0; i < TESTS; i++) {
+
+         for (int l = 0; l < CONSUMERS; l++) {
+            lost[l] = listeners[l].lost();
+         }
+         final long start = System.nanoTime();
+         for (int m = 0; m < MESSAGES; m++) {
+            channel.shout(1L);
+         }
+         final long elapsed = System.nanoTime() - start;
+         System.out.println((MESSAGES * 1000000000L) / elapsed + " msg/sec");
+         TimeUnit.SECONDS.sleep(2);
+         for (int l = 0; l < CONSUMERS; l++) {
+            System.out.println("lost msgs [" + (l + 1) + "]: " + (listeners[l].lost() - lost[l]));
+
+         }
+      }
+      for (Thread listenerRunner : listenerRunners) {
+         listenerRunner.interrupt();
+         listenerRunner.join();
+      }
+   }
+
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastChannelTptBatchListenBackoffNano.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastChannelTptBatchListenBackoffNano.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.jmh.throughput;
+
+import java.util.concurrent.locks.LockSupport;
+
+public class SpMulticastChannelTptBatchListenBackoffNano extends SpMulticastChannelTptBatchListenBackoffNone {
+
+   @Override
+   protected void backoff() {
+      LockSupport.parkNanos(1L);
+   }
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastChannelTptBatchListenBackoffNone.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastChannelTptBatchListenBackoffNone.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.jmh.throughput;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jctools.queues.MessagePassingQueue;
+import org.jctools.queues.SpMulticastChannel;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Group)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+public class SpMulticastChannelTptBatchListenBackoffNone {
+
+   private static final long DELAY_PRODUCER = Long.getLong("delay.p", 0L);
+   private static final long DELAY_CONSUMER = Long.getLong("delay.c", 0L);
+   Integer ONE = 777;
+   @Param(value = {"132000"})
+   String requestedCapacity;
+
+   SpMulticastChannel<Integer> channel;
+   SpMulticastChannel.Listener<Integer> listener;
+   private Integer escape;
+   private MessagePassingQueue.Consumer<Integer> consumer;
+
+   @Setup()
+   public void init() {
+      this.channel = new SpMulticastChannel<Integer>(Integer.parseInt(requestedCapacity));
+      this.listener = this.channel.newListener();
+      this.consumer = new MessagePassingQueue.Consumer<Integer>() {
+         @Override
+         public void accept(Integer e) {
+            if (e != ONE) {
+               escape = e;
+            }
+         }
+      };
+   }
+
+   @Benchmark
+   @Group("tpt")
+   public void shout() {
+      channel.shout(ONE);
+      if (DELAY_PRODUCER != 0) {
+         Blackhole.consumeCPU(DELAY_PRODUCER);
+      }
+   }
+
+   @Benchmark
+   @Group("tpt")
+   public void batchListen(PollCounters counters) {
+      final long oldLost = listener.lost();
+      final int listened = listener.listen(consumer);
+      final long newLost = listener.lost();
+      final long lost = newLost - oldLost;
+      if (lost > 0) {
+         counters.lost += lost;
+      }
+      if (listened == 0) {
+         counters.empty++;
+         backoff();
+      } else {
+         counters.listened += listened;
+      }
+      if (DELAY_CONSUMER != 0) {
+         Blackhole.consumeCPU(DELAY_CONSUMER);
+      }
+   }
+
+   protected void backoff() {
+
+   }
+
+   @Setup(Level.Iteration)
+   public void chase() {
+      listener.chase();
+   }
+
+   @AuxCounters
+   @State(Scope.Thread)
+   public static class PollCounters {
+
+      public long empty;
+      public long lost;
+      public long listened;
+
+      @Setup(Level.Iteration)
+      public void clean() {
+         empty = lost = listened = 0;
+      }
+   }
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastChannelTptBatchListenBackoffYield.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastChannelTptBatchListenBackoffYield.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.jmh.throughput;
+
+public class SpMulticastChannelTptBatchListenBackoffYield extends SpMulticastChannelTptBatchListenBackoffNone {
+
+   @Override
+   protected void backoff() {
+      Thread.yield();
+   }
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastLongChannelTptBatchListenBackoffNano.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastLongChannelTptBatchListenBackoffNano.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.jmh.throughput;
+
+import java.util.concurrent.locks.LockSupport;
+
+public class SpMulticastLongChannelTptBatchListenBackoffNano extends SpMulticastLongChannelTptBatchListenBackoffNone {
+
+   @Override
+   protected void backoff() {
+      LockSupport.parkNanos(1L);
+   }
+
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastLongChannelTptBatchListenBackoffNone.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastLongChannelTptBatchListenBackoffNone.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.jmh.throughput;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jctools.queues.SpMulticastLongChannel;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Group)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+public class SpMulticastLongChannelTptBatchListenBackoffNone {
+
+   private static final long DELAY_PRODUCER = Long.getLong("delay.p", 0L);
+   private static final long DELAY_CONSUMER = Long.getLong("delay.c", 0L);
+   long ONE = 777;
+   @Param(value = {"132000"})
+   String requestedCapacity;
+
+   SpMulticastLongChannel channel;
+   SpMulticastLongChannel.Listener listener;
+   private long escape;
+   private SpMulticastLongChannel.Listener.LongConsumer consumer;
+
+   @Setup()
+   public void init() {
+      this.channel = new SpMulticastLongChannel(Integer.parseInt(requestedCapacity));
+      this.listener = this.channel.newListener();
+      this.consumer = new SpMulticastLongChannel.Listener.LongConsumer() {
+         @Override
+         public void accept(long e) {
+            if (e != ONE) {
+               escape = e;
+            }
+         }
+      };
+   }
+
+   @Benchmark
+   @Group("tpt")
+   public void shout() {
+      channel.shout(ONE);
+      if (DELAY_PRODUCER != 0) {
+         Blackhole.consumeCPU(DELAY_PRODUCER);
+      }
+   }
+
+   @Benchmark
+   @Group("tpt")
+   public void batchListen(PollCounters counters) {
+      final long oldLost = listener.lost();
+      final int listened = listener.listen(consumer);
+      final long newLost = listener.lost();
+      final long lost = newLost - oldLost;
+      if (lost > 0) {
+         counters.lost += lost;
+      }
+      if (listened == 0) {
+         counters.empty++;
+         backoff();
+      } else {
+         counters.listened += listened;
+      }
+      if (DELAY_CONSUMER != 0) {
+         Blackhole.consumeCPU(DELAY_CONSUMER);
+      }
+   }
+
+   protected void backoff() {
+
+   }
+
+   @Setup(Level.Iteration)
+   public void chase() {
+      listener.chase();
+   }
+
+   @AuxCounters
+   @State(Scope.Thread)
+   public static class PollCounters {
+
+      public long empty;
+      public long lost;
+      public long listened;
+
+      @Setup(Level.Iteration)
+      public void clean() {
+         empty = lost = listened = 0;
+      }
+   }
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastLongChannelTptBatchListenBackoffYield.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/SpMulticastLongChannelTptBatchListenBackoffYield.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.jmh.throughput;
+
+public class SpMulticastLongChannelTptBatchListenBackoffYield extends SpMulticastLongChannelTptBatchListenBackoffNone {
+
+   @Override
+   protected void backoff() {
+      Thread.yield();
+   }
+
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/channels/ChannelBatchThroughputBackoffNone.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/channels/ChannelBatchThroughputBackoffNone.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.jmh.throughput.channels;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import org.jctools.channels.Channel;
+import org.jctools.channels.ChannelConsumer;
+import org.jctools.channels.ChannelProducer;
+import org.jctools.channels.ChannelReceiver;
+import org.jctools.channels.mpsc.MpscChannel;
+import org.jctools.channels.multicast.SpMulticastChannel;
+import org.jctools.channels.spsc.SpscChannel;
+import org.jctools.util.JvmInfo;
+import org.jctools.util.Pow2;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Group)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+public class ChannelBatchThroughputBackoffNone {
+
+   private static final long DELAY_PRODUCER = Long.getLong("delay.p", 0L);
+   private static final long DELAY_CONSUMER = Long.getLong("delay.c", 0L);
+   private static ThreadLocal<Object> marker = new ThreadLocal<Object>();
+   @Param(value = {"132000"})
+   int capacity;
+   @Param(value = {"SpMulticast", "Spsc", "Mpsc"})
+   ChannelThroughputBackoffNone.Type type;
+   int limit;
+   private ByteBuffer buffer;
+   private Channel<Ping> channel;
+   private ChannelProducer<Ping> producer;
+   private ChannelConsumer consumer;
+   private ChannelReceiver<Ping> receiver;
+
+   // Deliberately not a local to avoid constant folding.
+   private long writeValue = 1L;
+
+   public static void main(String[] args) throws RunnerException {
+      Options opt = new OptionsBuilder().include(ChannelBatchThroughputBackoffNone.class.getSimpleName()).build();
+
+      new Runner(opt).run();
+   }
+
+   @Setup
+   public void setup(final Blackhole blackhole) {
+      receiver = new ChannelReceiver<Ping>() {
+         @Override
+         public void accept(Ping element) {
+            blackhole.consume(element.getValue());
+         }
+      };
+      buffer = ByteBuffer.allocateDirect(Pow2.roundToPowerOfTwo(capacity * 2) * (8 + 4) + JvmInfo.CACHE_LINE_SIZE * 5);
+
+      switch (type) {
+         case Spsc:
+            channel = new SpscChannel<Ping>(buffer, capacity, Ping.class);
+            break;
+         case Mpsc:
+            channel = new MpscChannel<Ping>(buffer, capacity, Ping.class);
+            break;
+         case SpMulticast:
+            channel = new SpMulticastChannel<Ping>(buffer, capacity, Ping.class);
+            break;
+         default:
+            throw new IllegalArgumentException();
+      }
+      producer = channel.producer();
+      consumer = channel.consumer(receiver);
+      this.limit = channel.maximumCapacity();
+      OfferCounters oc = new OfferCounters();
+      PollCounters pc = new PollCounters();
+      for (int i = 0; i < 100000; i++) {
+         offer(oc);
+         poll(pc, null);
+      }
+   }
+
+   @Benchmark
+   @Group("tpt")
+   public void offer(OfferCounters counters) {
+      ChannelProducer<Ping> lProducer = producer;
+      if (!lProducer.claim()) {
+         counters.offersFailed++;
+      } else {
+         Ping element = lProducer.currentElement();
+         element.setValue(writeValue);
+         lProducer.commit();
+         counters.offersMade++;
+      }
+      if (DELAY_PRODUCER != 0) {
+         Blackhole.consumeCPU(DELAY_PRODUCER);
+      }
+   }
+
+   @Benchmark
+   @Group("tpt")
+   public void poll(PollCounters counters, ConsumerMarker cs) {
+      final int read = consumer.read(this.limit);
+      if (read == 0) {
+         counters.pollsFailed++;
+      } else {
+         counters.pollsMade += read;
+      }
+      if (DELAY_CONSUMER != 0) {
+         Blackhole.consumeCPU(DELAY_CONSUMER);
+      }
+   }
+
+   @TearDown(Level.Iteration)
+   public void emptyQ() {
+      if (marker.get() == null)
+         return;
+      // sadly the iteration tear down is performed from each participating thread, so we need to guess
+      // which is which (can't have concurrent access to poll).
+      //TODO use chase method for multicast channel!!!
+      for (int i = 0; i < 2; i++) {
+         while (consumer.read()) {
+
+         }
+      }
+   }
+
+   public enum Type {
+      Spsc, Mpsc, SpMulticast
+   }
+
+   @AuxCounters
+   @State(Scope.Thread)
+   public static class PollCounters {
+
+      public int pollsFailed;
+      public int pollsMade;
+
+      @Setup(Level.Iteration)
+      public void clean() {
+         pollsFailed = pollsMade = 0;
+      }
+   }
+
+   @AuxCounters
+   @State(Scope.Thread)
+   public static class OfferCounters {
+
+      public int offersFailed;
+      public int offersMade;
+
+      @Setup(Level.Iteration)
+      public void clean() {
+         offersFailed = offersMade = 0;
+      }
+   }
+
+   @State(Scope.Thread)
+   public static class ConsumerMarker {
+
+      public ConsumerMarker() {
+         marker.set(this);
+      }
+   }
+}

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/channels/ChannelThroughputBackoffNone.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/channels/ChannelThroughputBackoffNone.java
@@ -21,6 +21,7 @@ import org.jctools.channels.ChannelConsumer;
 import org.jctools.channels.ChannelProducer;
 import org.jctools.channels.ChannelReceiver;
 import org.jctools.channels.mpsc.MpscChannel;
+import org.jctools.channels.multicast.SpMulticastChannel;
 import org.jctools.channels.spsc.SpscChannel;
 import org.jctools.util.JvmInfo;
 import org.jctools.util.Pow2;
@@ -55,9 +56,9 @@ public class ChannelThroughputBackoffNone {
     @Param(value = { "132000" })
     int capacity;
     public enum Type{
-        Spsc,Mpsc
+        Spsc,Mpsc,SpMulticast
     }
-    @Param(value = { "Spsc", "Mpsc" })
+   @Param(value = {"SpMulticast", "Spsc", "Mpsc"})
     Type type;
     private ByteBuffer buffer;
     private Channel<Ping> channel;
@@ -86,7 +87,10 @@ public class ChannelThroughputBackoffNone {
         case Mpsc:
             channel = new MpscChannel<Ping>(buffer, capacity, Ping.class);
             break;
-        default:
+        case SpMulticast:
+            channel = new SpMulticastChannel<Ping>(buffer, capacity, Ping.class);
+            break;
+         default:
             throw new IllegalArgumentException();
         }
         producer = channel.producer();
@@ -105,10 +109,10 @@ public class ChannelThroughputBackoffNone {
         public int pollsFailed;
         public int pollsMade;
 
-//        @Setup(Level.Iteration)
-//        public void clean() {
-//            pollsFailed = pollsMade = 0;
-//        }
+        @Setup(Level.Iteration)
+        public void clean() {
+            pollsFailed = pollsMade = 0;
+        }
     }
 
     @AuxCounters
@@ -117,10 +121,10 @@ public class ChannelThroughputBackoffNone {
         public int offersFailed;
         public int offersMade;
 
-//        @Setup(Level.Iteration)
-//        public void clean() {
-//            offersFailed = offersMade = 0;
-//        }
+        @Setup(Level.Iteration)
+        public void clean() {
+            offersFailed = offersMade = 0;
+        }
     }
 
     private static ThreadLocal<Object> marker = new ThreadLocal<Object>();

--- a/jctools-experimental/pom.xml
+++ b/jctools-experimental/pom.xml
@@ -11,6 +11,10 @@
     <name>Experimental implementations</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <java.version>1.8</java.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jctools</groupId>

--- a/jctools-experimental/src/main/java/org/jctools/channels/ChannelConsumer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/ChannelConsumer.java
@@ -26,4 +26,18 @@ public interface ChannelConsumer {
      */
     boolean read();
 
+    /**
+     * Read as much message are available from the channel until limit.
+     *
+     * @param limit the maximum number of messages allowed to be read
+     * @return the number of the messages read
+     */
+    default int read(int limit) {
+        for (int i = 0; i < limit; i++) {
+            if (!read()) {
+                return i;
+            }
+        }
+        return limit;
+    }
 }

--- a/jctools-experimental/src/main/java/org/jctools/channels/multicast/ChannelLayout.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/multicast/ChannelLayout.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import org.jctools.util.JvmInfo;
+import org.jctools.util.Pow2;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+
+// Layout of the Channel (assuming 64b cache line):
+// buffer ((capacity * slotSize) aligned to cache line )
+// producerIndex(8b), pad(56b) |
+// pad(64b)
+// dummy(8b), pad(56b) |
+// pad(64b)
+final class ChannelLayout {
+
+   public static final int PRODUCER_INDEX_OFFSET = 0;
+   public static final int PRODUCER_INDEX_SIZE = 8;
+   public static final int HEADER_SIZE = JvmInfo.CACHE_LINE_SIZE * 2;
+
+   private ChannelLayout() {
+   }
+
+   public static long producerIndexAddress(long bufferAddress, final int messageContentBytes) {
+      return bufferAddress + messageContentBytes;
+   }
+
+   public static long lvCommittedSequence(long producerIndexAddress) {
+      return UNSAFE.getLongVolatile(null, producerIndexAddress);
+   }
+
+   public static long lpCommittedSequence(long producerIndexAddress) {
+      return UNSAFE.getLong(null, producerIndexAddress);
+   }
+
+   public static void soCommittedSequence(long producerIndexAddress, long value) {
+      UNSAFE.putOrderedLong(null, producerIndexAddress, value);
+   }
+
+   public static int messageContentBytes(final int capacity, final int messageSize) {
+      return (int) Pow2.align(Pow2.roundToPowerOfTwo(capacity) * MessageLayout.slotSize(messageSize), JvmInfo.CACHE_LINE_SIZE);
+   }
+
+   public static int getRequiredBufferSize(final int capacity, final int messageSize) {
+      return messageContentBytes(capacity, messageSize) + HEADER_SIZE;
+   }
+
+}

--- a/jctools-experimental/src/main/java/org/jctools/channels/multicast/MessageLayout.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/multicast/MessageLayout.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import org.jctools.util.Pow2;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+
+final class MessageLayout {
+
+   public static final int SEQUENCE_INDICATOR_SIZE = 8;
+   public static final int SEQUENCE_INDICATOR_OFFSET = 0;
+
+   private MessageLayout() {
+
+   }
+
+   public static long calcSequenceOffset(long bufferAddress, long index, long mask, int slotSize) {
+      return bufferAddress + ((index & mask) * slotSize);
+   }
+
+   public static void spSequence(long offset, long e) {
+      UNSAFE.putLong(null, offset, e);
+   }
+
+   public static void soSequence(long offset, long e) {
+      UNSAFE.putOrderedLong(null, offset, e);
+   }
+
+   public static long lvSequence(long offset) {
+      return UNSAFE.getLongVolatile(null, offset);
+   }
+
+   public static long lpSequence(long offset) {
+      return UNSAFE.getLong(null, offset);
+   }
+
+   public static int slotSize(int messageSize) {
+      return (int) Pow2.align(messageSize + SEQUENCE_INDICATOR_SIZE, SEQUENCE_INDICATOR_SIZE);
+   }
+
+}

--- a/jctools-experimental/src/main/java/org/jctools/channels/multicast/OffHeapFixedMessageSizeAppender.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/multicast/OffHeapFixedMessageSizeAppender.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import java.nio.ByteBuffer;
+
+import org.jctools.util.Pow2;
+import org.jctools.util.UnsafeDirectByteBuffer;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+
+final class OffHeapFixedMessageSizeAppender {
+
+   private final long mask;
+   private final int capacity;
+   private final int slotSize;
+   private final ByteBuffer buffer;
+   private final long producerIndexAddress;
+   private final long bufferAddress;
+
+   /**
+    * This is to be used for an IPC queue with the direct buffer used being a memory mapped file.
+    *
+    * @param buffer
+    * @param capacity    in messages, actual capacity will be
+    * @param messageSize
+    */
+   protected OffHeapFixedMessageSizeAppender(final ByteBuffer buffer, final int capacity, final int messageSize) {
+      final int requiredCapacity = ChannelLayout.getRequiredBufferSize(capacity, messageSize);
+      if (buffer.capacity() < requiredCapacity) {
+         throw new IllegalStateException("buffer is not big enough; required capacity is " + requiredCapacity + " bytes!");
+      }
+      this.bufferAddress = UnsafeDirectByteBuffer.getAddress(buffer);
+      this.slotSize = MessageLayout.slotSize(messageSize);
+      this.capacity = Pow2.roundToPowerOfTwo(capacity);
+      this.mask = this.capacity - 1;
+      final int messageContentBytes = ChannelLayout.messageContentBytes(capacity, messageSize);
+      this.producerIndexAddress = ChannelLayout.producerIndexAddress(this.bufferAddress, messageContentBytes);
+      this.buffer = buffer;
+   }
+
+   public ByteBuffer buffer() {
+      return buffer;
+   }
+
+   public int capacity() {
+      return this.capacity;
+   }
+
+   public long shouts() {
+      return ChannelLayout.lvCommittedSequence(this.producerIndexAddress);
+   }
+
+   public long messageOffset(long sequence) {
+      return MessageLayout.calcSequenceOffset(bufferAddress, sequence, mask, slotSize) + MessageLayout.SEQUENCE_INDICATOR_SIZE;
+   }
+
+   public long writeAcquire() {
+      final long mask = this.mask;
+      final long producerIndexAddress = this.producerIndexAddress;
+      final long bufferAddress = this.bufferAddress;
+      final int slotSize = this.slotSize;
+
+      final long sequence = ChannelLayout.lpCommittedSequence(producerIndexAddress);
+      //publish sequence's intent
+      final long sequenceOffset = MessageLayout.calcSequenceOffset(bufferAddress, sequence, mask, slotSize);
+      MessageLayout.spSequence(sequenceOffset, sequence);
+      UNSAFE.storeFence();
+      //StoreStore + LoadStore
+      //any message content written after the explicit fence will act as a write-release that will publish the sequence's intent too.
+      //A tailer can use this "leak" to recognize if a read-acquired content is no longer valid by checking that the leaked value of the sequence is not changed
+      //from the first value read (that was previously written in the writeRelease phase)
+      return sequence;
+   }
+
+   public void writeRelease(final long sequence) {
+      final long producerIndexAddress = this.producerIndexAddress;
+      final long sequenceOffset = MessageLayout.calcSequenceOffset(this.bufferAddress, sequence, this.mask, this.slotSize);
+      final long nextSequence = sequence + 1;
+      //StoreStore + LoadStore
+      //the write-release of the sequence allows a consumer that perform a read-acquire of it to read safely the message content too,
+      //until a new intent will change this same sequence value.
+      MessageLayout.soSequence(sequenceOffset, nextSequence);
+      //StoreStore + LoadStore
+      ChannelLayout.soCommittedSequence(producerIndexAddress, nextSequence);
+   }
+}

--- a/jctools-experimental/src/main/java/org/jctools/channels/multicast/OffHeapFixedMessageSizeTailer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/multicast/OffHeapFixedMessageSizeTailer.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import java.nio.ByteBuffer;
+import java.util.function.LongConsumer;
+
+import org.jctools.util.JvmInfo;
+import org.jctools.util.Pow2;
+import org.jctools.util.UnsafeDirectByteBuffer;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+
+final class OffHeapFixedMessageSizeTailer {
+
+   public static long EOF = -1;
+   public static long LOST = -2;
+   private final long mask;
+   private final int capacity;
+   private final int messageSize;
+   private final int slotSize;
+   private final ByteBuffer buffer;
+   private final long producerIndexAddress;
+   private final long bufferAddress;
+   private final ByteBuffer messageCopy;
+   private final long messageCopyAddress;
+   private final long listenedAddress;
+   private final long lostAddress;
+
+   /**
+    * This is to be used for an IPC queue with the direct buffer used being a memory mapped file.
+    *
+    * @param buffer
+    * @param capacity    in messages, actual capacity will be
+    * @param messageSize
+    */
+   protected OffHeapFixedMessageSizeTailer(final ByteBuffer buffer, final int capacity, final int messageSize) {
+      final int requiredCapacity = ChannelLayout.getRequiredBufferSize(capacity, messageSize);
+      if (buffer.capacity() < requiredCapacity) {
+         throw new IllegalStateException("buffer is not big enough; required capacity is " + requiredCapacity + " bytes!");
+      }
+      this.bufferAddress = UnsafeDirectByteBuffer.getAddress(buffer);
+      this.messageSize = messageSize;
+      this.slotSize = MessageLayout.slotSize(messageSize);
+      this.capacity = Pow2.roundToPowerOfTwo(capacity);
+      this.mask = this.capacity - 1;
+      final int messageContentBytes = ChannelLayout.messageContentBytes(capacity, messageSize);
+      this.producerIndexAddress = ChannelLayout.producerIndexAddress(this.bufferAddress, messageContentBytes);
+      this.buffer = buffer;
+      final int messageCopySize = (int) Pow2.align(messageSize, JvmInfo.CACHE_LINE_SIZE * 2);
+      this.messageCopy = UnsafeDirectByteBuffer.allocateAlignedByteBuffer(messageCopySize + TailerLayout.HEADER_SIZE, JvmInfo.CACHE_LINE_SIZE);
+      this.messageCopyAddress = UnsafeDirectByteBuffer.getAddress(messageCopy);
+      final long endOfMesssageCopyAddress = messageCopyAddress + messageCopySize;
+      this.listenedAddress = TailerLayout.listenedAddress(endOfMesssageCopyAddress);
+      this.lostAddress = TailerLayout.lostAddress(endOfMesssageCopyAddress);
+   }
+
+   private static long chase(long listenedSequence, long sequence, long lost, long lostAddress, long listenedAddress) {
+      final long oldListenedSequence = listenedSequence;
+      //if is claimed -> previous sequence is ok
+      //if is committed -> current sequence is ok
+      listenedSequence = sequence - 1;
+      final long lostElements = listenedSequence - oldListenedSequence;
+      lost += lostElements;
+      TailerLayout.soLost(lostAddress, lost);
+      TailerLayout.spListened(listenedAddress, listenedSequence);
+      return listenedSequence;
+   }
+
+   public ByteBuffer buffer() {
+      return buffer;
+   }
+
+   public int capacity() {
+      return this.capacity;
+   }
+
+   public long messageCopyAddress() {
+      return this.messageCopyAddress;
+   }
+
+   public int read(LongConsumer consumer, int limit) {
+      final long mask = this.mask;
+      final long bufferAddress = this.bufferAddress;
+      final int slotSize = this.slotSize;
+      final long listenedAddress = this.listenedAddress;
+      final long lostAddress = this.lostAddress;
+      final long messageCopyAddress = this.messageCopyAddress;
+      final long messageSize = this.messageSize;
+      long listenedSequence = TailerLayout.lpListened(listenedAddress);
+      final long lost = TailerLayout.lpLost(lostAddress);
+
+      for (int i = 0; i < limit; i++) {
+         final long sequenceOffset = MessageLayout.calcSequenceOffset(bufferAddress, listenedSequence, mask, slotSize);
+         long sequence = MessageLayout.lvSequence(sequenceOffset);
+         //LoadLoad + LoadStore
+         final long expectedCommittedSequence = listenedSequence + 1;
+         if (sequence == expectedCommittedSequence) {
+            //listened sequence is committed, can bulk copy the message
+            final long elementOffset = sequenceOffset + MessageLayout.SEQUENCE_INDICATOR_SIZE;
+            //this content read before the explicit fence will act as a read-acquire that allows the last sequence's intent to leak and be read atomically, if changed
+            UNSAFE.copyMemory(elementOffset, messageCopyAddress, messageSize);
+            UNSAFE.loadFence();
+            //LoadLoad + LoadStore
+            sequence = MessageLayout.lvSequence(sequenceOffset);
+            //LoadLoad + LoadStore
+            //still valid?
+            if (sequence == expectedCommittedSequence) {
+               //is valid: the first read-acquire on the sequence has copied a valid content of the message
+               consumer.accept(messageCopyAddress);
+               listenedSequence++;
+            } else {
+               chase(listenedSequence, sequence, lost, lostAddress, listenedAddress);
+               return i;
+            }
+         } else {
+            if (sequence > expectedCommittedSequence) {
+               chase(listenedSequence, sequence, lost, lostAddress, listenedAddress);
+               return i;
+            } else {
+               TailerLayout.spListened(listenedAddress, listenedSequence);
+               //empty!
+               return i;
+            }
+         }
+      }
+      //no loss is experienced!
+      TailerLayout.spListened(listenedAddress, listenedSequence);
+      return limit;
+
+   }
+
+   public long readAcquire() {
+      final long mask = this.mask;
+      final long bufferAddress = this.bufferAddress;
+      final int slotSize = this.slotSize;
+      final long listenedAddress = this.listenedAddress;
+      final long lostAddress = this.lostAddress;
+      final long messageCopyAddress = this.messageCopyAddress;
+      final long messageSize = this.messageSize;
+
+      final long listenedSequence = TailerLayout.lpListened(listenedAddress);
+      long lost = TailerLayout.lpLost(lostAddress);
+
+      final long sequenceOffset = MessageLayout.calcSequenceOffset(bufferAddress, listenedSequence, mask, slotSize);
+      long sequence = MessageLayout.lvSequence(sequenceOffset);
+      //LoadLoad + LoadStore
+      final long expectedCommittedSequence = listenedSequence + 1;
+      if (sequence == expectedCommittedSequence) {
+         //listened sequence is committed, can bulk copy the message
+         final long elementOffset = sequenceOffset + MessageLayout.SEQUENCE_INDICATOR_SIZE;
+         //this content read before the explicit fence will act as a read-racquire that allows the last sequence's intent to leak and be read atomically, if changed
+         UNSAFE.copyMemory(elementOffset, messageCopyAddress, messageSize);
+         UNSAFE.loadFence();
+         //LoadLoad + LoadStore
+         sequence = MessageLayout.lvSequence(sequenceOffset);
+         //LoadLoad + LoadStore
+         //still valid?
+         if (sequence == expectedCommittedSequence) {
+            //is valid: the first read-acquire on the sequence has copied a valid content of the message
+            return listenedSequence;
+         } else {
+            //lost experienced!
+            chase(listenedSequence, sequence, lost, lostAddress, listenedAddress);
+            return LOST;
+         }
+      } else {
+         if (sequence > expectedCommittedSequence) {
+            //lost experienced!
+            chase(listenedSequence, sequence, lost, lostAddress, listenedAddress);
+            return LOST;
+         } else {
+            //empty!
+            return EOF;
+         }
+      }
+   }
+
+   public void readRelease(long listenedSequence) {
+      final long listenedAddress = this.listenedAddress;
+      final long nextListenedSequence = listenedSequence + 1;
+      TailerLayout.spListened(listenedAddress, nextListenedSequence);
+   }
+
+   public long chase() {
+      final long producerIndexAddress = this.producerIndexAddress;
+      final long listenedAddress = this.listenedAddress;
+      final long lostAddress = this.lostAddress;
+
+      final long sequenceToChase = Math.max(0, ChannelLayout.lvCommittedSequence(producerIndexAddress) - 1);
+      final long lostSequence = sequenceToChase - TailerLayout.lpListened(listenedAddress);
+      TailerLayout.spListened(listenedAddress, sequenceToChase);
+      final long oldLost = TailerLayout.lpLost(lostAddress);
+      TailerLayout.soLost(lostAddress, oldLost + lostSequence);
+      return lostSequence;
+   }
+
+   public long lost() {
+      return TailerLayout.lvLost(this.lostAddress);
+   }
+}

--- a/jctools-experimental/src/main/java/org/jctools/channels/multicast/SpMulticastChannel.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/multicast/SpMulticastChannel.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import java.nio.ByteBuffer;
+
+import org.jctools.channels.Channel;
+import org.jctools.channels.ChannelReceiver;
+import org.jctools.channels.mapping.Mapper;
+import org.jctools.util.Pow2;
+import org.jctools.util.Template;
+
+/**
+ * A Single-Producer channel backed by a pre-allocated buffer.
+ * It allows enough fast multiple (0 or more) {@link SpMulticastChannelConsumer}s to receive the messages.
+ * The {@link SpMulticastChannelProducer} can't be stopped by any slow {@link SpMulticastChannelConsumer} that
+ * could experience losses when not fast enough.
+ */
+public final class SpMulticastChannel<E> implements Channel<E> {
+
+   private static final boolean debugEnabled = Boolean.getBoolean("jctools.channels.compile.dump");
+
+   private final int elementSize;
+   private final Mapper<E> mapper;
+   private final ByteBuffer buffer;
+   private final int requestedCapacity;
+   private final int maximumCapacity;
+   private final SpMulticastChannelProducer<E> producer;
+
+   /**
+    * This is to be used for an IPC queue with the direct buffer used being a memory mapped file.
+    *
+    * @param buffer
+    * @param requestedCapacity
+    */
+   public SpMulticastChannel(final ByteBuffer buffer, final int requestedCapacity, final Class<E> type) {
+      this.requestedCapacity = requestedCapacity;
+      this.maximumCapacity = Pow2.roundToPowerOfTwo(requestedCapacity);
+      this.buffer = buffer;
+      this.mapper = new Mapper<E>(type, debugEnabled);
+      this.elementSize = mapper.getSizeInBytes();
+
+      checkSufficientCapacity();
+      checkByteBuffer();
+
+      producer = newProducer(type, buffer, requestedCapacity, elementSize);
+   }
+
+   private void checkByteBuffer() {
+      if (!buffer.isDirect()) {
+         throw new IllegalArgumentException("Channels only work with direct or memory mapped buffers");
+      }
+   }
+
+   private void checkSufficientCapacity() {
+      final int requiredCapacityInBytes = ChannelLayout.getRequiredBufferSize(requestedCapacity, elementSize);
+      if (buffer.capacity() < requiredCapacityInBytes) {
+         throw new IllegalArgumentException("Failed to meet required maximumCapacity in bytes: " + requiredCapacityInBytes);
+      }
+   }
+
+   /**
+    * {@inherited}
+    */
+   @Override
+   public SpMulticastChannelConsumer<E> consumer(ChannelReceiver<E> receiver) {
+      return newConsumer(buffer, requestedCapacity, elementSize, receiver);
+   }
+
+   /**
+    * {@inherited}
+    */
+   @Override
+   public SpMulticastChannelProducer<E> producer() {
+      return producer;
+   }
+
+   /**
+    * @deprecated Due to the nature of the {@link SpMulticastChannelConsumer} that act as reader not capable to "consume"
+    * any message of the produced stream, this value is near to useless, but anyway provides a behaviour consistent
+    * with the original contract of {@link Channel#size}.
+    *
+    * {@inherited}
+    */
+   public int size() {
+      return this.producer.size();
+   }
+
+   /**
+    * {@inherited}
+    */
+   @Override
+   public int maximumCapacity() {
+      return this.maximumCapacity;
+   }
+
+   /**
+    * {@inherited}
+    */
+   @Override
+   public int requestedCapacity() {
+      return requestedCapacity;
+   }
+
+   /**
+    * @deprecated Due to the nature of the {@link SpMulticastChannelConsumer} that act as reader not capable to "consume"
+    * any message of the produced stream, this value is near to useless, but anyway provides a behaviour consistent
+    * with the original contract of {@link Channel#isEmpty()}.
+    *
+    * {@inherited}
+    */
+   public boolean isEmpty() {
+      return size() == 0;
+   }
+
+   @SuppressWarnings("unchecked")
+   private SpMulticastChannelProducer<E> newProducer(final Class<E> type, final Object... args) {
+      return mapper.newFlyweight(SpMulticastChannelProducer.class, "ChannelProducerTemplate.java", Template.fromFile(Channel.class, "ChannelProducerTemplate.java"), args);
+   }
+
+   @SuppressWarnings("unchecked")
+   private SpMulticastChannelConsumer<E> newConsumer(Object... args) {
+      return mapper.newFlyweight(SpMulticastChannelConsumer.class, "ChannelBatchConsumerTemplate.java", Template.fromFile(Channel.class, "ChannelBatchConsumerTemplate.java"), args);
+   }
+
+}

--- a/jctools-experimental/src/main/java/org/jctools/channels/multicast/SpMulticastChannelConsumer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/multicast/SpMulticastChannelConsumer.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import java.nio.ByteBuffer;
+import java.util.function.LongConsumer;
+
+import org.jctools.channels.ChannelConsumer;
+import org.jctools.channels.ChannelReceiver;
+
+/**
+ * {@inheritDoc}
+ *
+ * It allows sequentially reading messages from a {@link SpMulticastChannel}.
+ * It can join the transmission at any point without slowing down the {@link SpMulticastChannelProducer}.
+ * If it cannot keep up with the transmission loss will be experienced and recorded.
+ */
+public abstract class SpMulticastChannelConsumer<E> implements ChannelConsumer {
+
+   protected static final long EOF = OffHeapFixedMessageSizeTailer.EOF;
+   protected final ChannelReceiver<E> receiver;
+   private final OffHeapFixedMessageSizeTailer tailer;
+   private final long messageCopyAddress;
+   protected long pointer;
+   private long sequence;
+
+   public SpMulticastChannelConsumer(final ByteBuffer buffer,
+                                     final int capacity,
+                                     final int messageSize,
+                                     final ChannelReceiver<E> receiver) {
+      this.tailer = new OffHeapFixedMessageSizeTailer(buffer, capacity, messageSize);
+      this.receiver = receiver;
+      this.sequence = EOF;
+      this.pointer = EOF;
+      this.messageCopyAddress = tailer.messageCopyAddress();
+   }
+
+   /**
+    * Force this consumer to chase the last message thrown in the channel.
+    *
+    * @return the number of elements lost by this listener due to the chase
+    */
+   public final long chase() {
+      return this.tailer.chase();
+   }
+
+   /**
+    * The number of messages lost by this consumer until the creation of the listened {@link SpMulticastChannel}.
+    * This method's accuracy is subject to concurrent modifications happening.
+    *
+    * @return the number of messages lost by this consumer
+    */
+   public final long lost() {
+      return this.tailer.lost();
+   }
+
+   /**
+    * {@inheritDoc}
+    *
+    * It could returns if unable to keep up on the messages flow.
+    */
+   protected final int read(LongConsumer onReadPointer, int limit) {
+      return this.tailer.read(onReadPointer, limit);
+   }
+
+   protected final long readAcquire() {
+      final long sequence = this.tailer.readAcquire();
+      if (sequence >= 0) {
+         this.sequence = sequence;
+         return this.messageCopyAddress;
+      } else {
+         return EOF;
+      }
+   }
+
+   protected final void readRelease(long pointer) {
+      if (pointer != this.messageCopyAddress) {
+         throw new IllegalStateException("BAD TEMPLATE IMPLEMENTATION!");
+      }
+      this.tailer.readRelease(this.sequence);
+   }
+
+}

--- a/jctools-experimental/src/main/java/org/jctools/channels/multicast/SpMulticastChannelProducer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/multicast/SpMulticastChannelProducer.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import java.nio.ByteBuffer;
+
+import org.jctools.channels.ChannelProducer;
+
+/**
+ * {@inheritDoc}
+ *
+ * This producer by contract can't return {@code false} on {@link #claim} and will not stop to produce even
+ * if a {@link SpMulticastChannelConsumer} would die.
+ */
+public abstract class SpMulticastChannelProducer<E> implements ChannelProducer<E> {
+
+   private final OffHeapFixedMessageSizeAppender appender;
+   protected long pointer;
+   private long sequence;
+
+   public SpMulticastChannelProducer(final ByteBuffer buffer, final int capacity, final int messageSize) {
+      this.appender = new OffHeapFixedMessageSizeAppender(buffer, capacity, messageSize);
+      this.sequence = -1;
+      this.pointer = -1;
+   }
+
+   final int size() {
+      return (int) Math.min(this.appender.shouts(), this.appender.capacity());
+   }
+
+   /**
+    * The number of elements produced.
+    * This method's accuracy is subject to concurrent modifications happening.
+    *
+    * @return number of messages thrown in the {@link SpMulticastChannel}
+    */
+   public final long produced() {
+      return this.appender.shouts();
+   }
+
+   /**
+    * {@inheritDoc}
+    *
+    * @return true
+    */
+   @Override
+   public final boolean claim() {
+      this.sequence = this.appender.writeAcquire();
+      this.pointer = this.appender.messageOffset(sequence);
+      return true;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public final boolean commit() {
+      if (sequence < 0)
+         return false;
+      this.appender.writeRelease(sequence);
+      this.pointer = -1;
+      this.sequence = -1;
+      return true;
+   }
+
+}

--- a/jctools-experimental/src/main/java/org/jctools/channels/multicast/TailerLayout.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/multicast/TailerLayout.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import org.jctools.util.JvmInfo;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+
+// Layout of the Tailer statistics (assuming 64b cache line):
+// listenedSequence(8b), pad(56b) |
+// pad(64b)
+// lost(8b), pad(56b) |
+// pad(64b)
+// dummy(8b), pad(56b) |
+// pad(64b)
+final class TailerLayout {
+
+   public static final int LISTENED_OFFSET = 0;
+   public static final int LISTENED_SIZE = 8;
+   public static final int LOST_OFFSET = JvmInfo.CACHE_LINE_SIZE * 2;
+   public static final int LOST_SIZE = 8;
+   public static final int HEADER_SIZE = JvmInfo.CACHE_LINE_SIZE * 4;
+
+   private TailerLayout() {
+   }
+
+   public static long listenedAddress(long bufferAddress) {
+      return bufferAddress + LISTENED_OFFSET;
+   }
+
+   public static long lostAddress(long bufferAddress) {
+      return bufferAddress + LOST_OFFSET;
+   }
+
+   public static long lpListened(long listenedAddress) {
+      return UNSAFE.getLong(null, listenedAddress);
+   }
+
+   public static void spListened(long listenedAddress, long value) {
+      UNSAFE.putLong(null, listenedAddress, value);
+   }
+
+   public static long lpLost(long lostAddress) {
+      return UNSAFE.getLong(null, lostAddress);
+   }
+
+   public static long lvLost(long lostAddress) {
+      return UNSAFE.getLongVolatile(null, lostAddress);
+   }
+
+   public static void soLost(long lostAddress, long value) {
+      UNSAFE.putOrderedLong(null, lostAddress, value);
+   }
+
+}

--- a/jctools-experimental/src/main/java/org/jctools/queues/SpMulticastChannel.java
+++ b/jctools-experimental/src/main/java/org/jctools/queues/SpMulticastChannel.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.queues;
+
+import org.jctools.util.JvmInfo;
+import org.jctools.util.Pow2;
+import org.jctools.util.UnsafeAccess;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+import static org.jctools.util.UnsafeRefArrayAccess.lvElement;
+import static org.jctools.util.UnsafeRefArrayAccess.soElement;
+
+abstract class SpMulticatChannelL0Pad {
+
+   long p01, p02, p03, p04, p05, p06, p07;
+   long p10, p11, p12, p13, p14, p15, p16, p17;
+}
+
+abstract class SpMulticatChannelSequenceFields extends SpMulticatChannelL0Pad {
+
+   private static final long COMMITTED_SEQUENCE_OFFSET;
+
+   static {
+      try {
+         COMMITTED_SEQUENCE_OFFSET = UNSAFE.objectFieldOffset(SpMulticatChannelSequenceFields.class.getDeclaredField("committedSequence"));
+      } catch (NoSuchFieldException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   private volatile long committedSequence;
+
+   protected final long lpCommittedSequence() {
+      return UNSAFE.getLong(this, COMMITTED_SEQUENCE_OFFSET);
+   }
+
+   protected final void soCommittedSequence(long value) {
+      UNSAFE.putOrderedLong(this, COMMITTED_SEQUENCE_OFFSET, value);
+   }
+
+   protected final long lvCommittedSequence() {
+      return UNSAFE.getLongVolatile(this, COMMITTED_SEQUENCE_OFFSET);
+   }
+
+}
+
+abstract class SpMulticatChannelL1Pad extends SpMulticatChannelSequenceFields {
+
+   long p01, p02, p03, p04, p05, p06, p07;
+   long p10, p11, p12, p13, p14, p15, p16, p17;
+}
+
+/**
+ * A Single-Producer channel backed by a pre-allocated buffer.
+ * It allows enough fast multiple (0 or more) {@link Listener}s to receive the messages.
+ */
+public final class SpMulticastChannel<E> extends SpMulticatChannelL1Pad {
+
+   protected static final int SEQ_BUFFER_PAD;
+   private static final long ARRAY_BASE;
+   private static final int ELEMENT_SHIFT;
+
+   static {
+      final int scale = UnsafeAccess.UNSAFE.arrayIndexScale(long[].class);
+      if (8 == scale) {
+         ELEMENT_SHIFT = 3;
+      } else {
+         throw new IllegalStateException("Unexpected long[] element size");
+      }
+      // 2 cache lines pad
+      SEQ_BUFFER_PAD = (JvmInfo.CACHE_LINE_SIZE * 2) / scale;
+      // Including the buffer pad in the array base offset
+      ARRAY_BASE = UnsafeAccess.UNSAFE.arrayBaseOffset(long[].class) + (SEQ_BUFFER_PAD * scale);
+   }
+
+   private final long mask;
+   private final int capacity;
+   private final E[] buffer;
+   private final long[] sequenceBuffer;
+
+   public SpMulticastChannel(int capacity) {
+      final int actualCapacity = Pow2.roundToPowerOfTwo(capacity);
+      this.mask = actualCapacity - 1;
+      this.capacity = actualCapacity;
+      this.buffer = PaddedCircularArrayOffsetCalculator.allocate(actualCapacity);
+      // pad data on either end with some empty slots.
+      this.sequenceBuffer = new long[actualCapacity + SEQ_BUFFER_PAD * 2];
+   }
+
+   private static long calcSequenceOffset(long index, long mask) {
+      return ARRAY_BASE + ((index & mask) << ELEMENT_SHIFT);
+   }
+
+   private static final void spSequence(long[] buffer, long offset, long e) {
+      UNSAFE.putLong(buffer, offset, e);
+   }
+
+   private static final void soSequence(long[] buffer, long offset, long e) {
+      UNSAFE.putOrderedLong(buffer, offset, e);
+   }
+
+   private static final long lvSequence(long[] buffer, long offset) {
+      return UNSAFE.getLongVolatile(buffer, offset);
+   }
+
+   /**
+    * @param index desirable element index
+    * @param mask
+    * @return the offset in bytes within the array for a given index.
+    */
+   private static long calcElementOffset(long index, long mask) {
+      return PaddedCircularArrayOffsetCalculator.calcElementOffset(index, mask);
+   }
+
+   /**
+    * @return the capacity of this channel
+    */
+   public int capacity() {
+      return this.capacity;
+   }
+
+   /**
+    * The number of elements passed into the channel.
+    * This method's accuracy is subject to concurrent modifications happening.
+    *
+    * @return number of messages thrown in the channel
+    */
+   public long shouts() {
+      return lvCommittedSequence();
+   }
+
+   /**
+    * Inserts the specified element into this channel.
+    * It can be called safely only by one producer thread.
+    *
+    * @param item not null, will throw NPE if it is
+    */
+   public void shout(E item) {
+      if (item == null)
+         throw new NullPointerException("can't shout null values!");
+      final E[] buffer = this.buffer;
+      final long[] sequenceBuffer = this.sequenceBuffer;
+      final long mask = this.mask;
+      final long sequence = lpCommittedSequence();
+      final long nextSequence = sequence + 1;
+
+      final long sequenceOffset = calcSequenceOffset(sequence, mask);
+      spSequence(sequenceBuffer, sequenceOffset, sequence);
+      //StoreStore + LoadStore
+      soElement(buffer, calcElementOffset(sequence, mask), item);
+      //StoreStore + LoadStore
+      soSequence(sequenceBuffer, sequenceOffset, nextSequence);
+      //StoreStore + LoadStore
+      soCommittedSequence(nextSequence);
+   }
+
+   /**
+    * Creates an instance of {@link Listener} which can be used for sequential reads from this channel.
+    *
+    * @return a new {@link Listener} instance
+    */
+   public Listener<E> newListener() {
+      return new Listener<E>(this);
+   }
+
+   abstract static class ListenerL0Pad {
+
+      long p01, p02, p03, p04, p05, p06, p07;
+      long p10, p11, p12, p13, p14, p15, p16, p17;
+   }
+
+   abstract static class ListenerLostField extends ListenerL0Pad {
+
+      private static final long LOST_OFFSET;
+
+      static {
+         try {
+            LOST_OFFSET = UNSAFE.objectFieldOffset(ListenerLostField.class.getDeclaredField("lost"));
+         } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+         }
+      }
+
+      private volatile long lost;
+
+      protected final long lpLost() {
+         return UNSAFE.getLong(this, LOST_OFFSET);
+      }
+
+      protected final long lvLost() {
+         return UNSAFE.getLongVolatile(this, LOST_OFFSET);
+      }
+
+      protected final void spLost(long value) {
+         UNSAFE.putLong(this, LOST_OFFSET, value);
+      }
+
+      protected final void soLost(long value) {
+         UNSAFE.putOrderedLong(this, LOST_OFFSET, value);
+      }
+
+   }
+
+   abstract static class ListenerL1Pad extends ListenerLostField {
+
+      long p01, p02, p03, p04, p05, p06, p07;
+      long p10, p11, p12, p13, p14, p15, p16, p17;
+   }
+
+   abstract static class ListenerSequenceField extends ListenerL1Pad {
+
+      protected long listenedSequence;
+
+   }
+
+   abstract static class ListenerL2Pad extends ListenerSequenceField {
+
+      long p01, p02, p03, p04, p05, p06, p07;
+      long p10, p11, p12, p13, p14, p15, p16, p17;
+   }
+
+   /**
+    * It allows sequentially reading messages from a {@link SpMulticastChannel}.
+    * It can join the transmission at any point without slowing down the producer.
+    * If it cannot keep up with the transmission loss will be experienced and recorded.
+    *
+    * @param <E>
+    */
+   public static final class Listener<E> extends ListenerL2Pad {
+
+      private final SpMulticastChannel<E> channel;
+      private final E[] buffer;
+      private final long[] sequenceBuffer;
+      private final int capacity;
+      private final long mask;
+
+      private Listener(SpMulticastChannel<E> channel) {
+         this.channel = channel;
+         this.capacity = channel.capacity;
+         this.mask = channel.mask;
+         this.buffer = channel.buffer;
+         this.sequenceBuffer = channel.sequenceBuffer;
+      }
+
+      private static void chase(long listenedSequence, long sequence, long lost, Listener listener) {
+         final long oldListenedSequence = listenedSequence;
+         //if is claimed -> previous sequence is ok
+         //if is committed -> current sequence is ok
+         listenedSequence = sequence - 1;
+         final long lostElements = listenedSequence - oldListenedSequence;
+         lost += lostElements;
+         listener.soLost(lost);
+         listener.listenedSequence = listenedSequence;
+      }
+
+      /**
+       * @see SpMulticastChannel#capacity()
+       */
+      public int capacity() {
+         return this.capacity;
+      }
+
+      /**
+       * Transfer all available items from the channel and hand to consume.
+       * It returns when loss is experienced, with {@link #lost()} incremented by the size of the lost items.
+       *
+       * @return the number of polled elements
+       */
+      public int listen(MessagePassingQueue.Consumer<? super E> onMessage) {
+         return listen(onMessage, this.capacity);
+      }
+
+      /**
+       * Transfer up to {@code limit} items from the channel and hand to consume.
+       * It returns when loss is experienced, with {@link #lost()} incremented by the size of the lost items.
+       *
+       * @return the number of polled elements
+       */
+      public int listen(MessagePassingQueue.Consumer<? super E> onMessage, int limit) {
+         final E[] buffer = this.buffer;
+         final long[] sequenceBuffer = this.sequenceBuffer;
+         final long mask = this.mask;
+         long listenedSequence = this.listenedSequence;
+         final long lost = lpLost();
+
+         for (int i = 0; i < limit; i++) {
+            final long sequenceOffset = calcSequenceOffset(listenedSequence, mask);
+            long sequence = lvSequence(sequenceBuffer, sequenceOffset);
+            //LoadLoad + LoadStore
+            final long expectedCommittedSequence = listenedSequence + 1;
+            if (sequence == expectedCommittedSequence) {
+               //listened sequence is committed, can read
+               final long elementOffset = calcElementOffset(listenedSequence, mask);
+               final E element = lvElement(buffer, elementOffset);
+               //LoadLoad + LoadStore
+               //TODO a plain load could be enough?
+               sequence = lvSequence(sequenceBuffer, sequenceOffset);
+               //LoadLoad + LoadStore
+               //still valid?
+               if (sequence == expectedCommittedSequence) {
+                  onMessage.accept(element);
+                  //move to the next element
+                  listenedSequence++;
+               } else {
+                  //lost experienced!
+                  chase(listenedSequence, sequence, lost, this);
+                  return i;
+               }
+            } else {
+               if (sequence > expectedCommittedSequence) {
+                  //lost experienced!
+                  chase(listenedSequence, sequence, lost, this);
+                  return i;
+               } else {
+                  //empty!
+                  this.listenedSequence = listenedSequence;
+                  return i;
+               }
+            }
+         }
+         //no loss is experienced!
+         this.listenedSequence = listenedSequence;
+         return limit;
+      }
+
+      /**
+       * Retrieves one item from the channel, if available.
+       * It returns {@code null} if there are no new items available or loss is experienced.
+       *
+       * @return the item of the channel or {@code null} if loss is experienced or no new items are available
+       */
+      public E listen() {
+         final E[] buffer = this.buffer;
+         final long[] sequenceBuffer = this.sequenceBuffer;
+         final long mask = this.mask;
+         final long listenedSequence = this.listenedSequence;
+         final long lost = lpLost();
+
+         final long sequenceOffset = calcSequenceOffset(listenedSequence, mask);
+         long sequence = lvSequence(sequenceBuffer, sequenceOffset);
+         //LoadLoad + LoadStore
+         final long expectedCommittedSequence = listenedSequence + 1;
+         if (sequence == expectedCommittedSequence) {
+            //listened sequence is committed, can read
+            final long elementOffset = calcElementOffset(listenedSequence, mask);
+            final E element = lvElement(buffer, elementOffset);
+            //LoadLoad + LoadStore
+            //TODO a plain load could be enough?
+            sequence = lvSequence(sequenceBuffer, sequenceOffset);
+            //LoadLoad + LoadStore
+            //still valid?
+            if (sequence == expectedCommittedSequence) {
+               //move to the next element
+               this.listenedSequence = listenedSequence + 1;
+               return element;
+            } else {
+               //lost experienced!
+               chase(listenedSequence, sequence, lost, this);
+               return null;
+            }
+         } else {
+            if (sequence > expectedCommittedSequence) {
+               //lost experienced!
+               chase(listenedSequence, sequence, lost, this);
+               return null;
+            } else {
+               //empty!
+               return null;
+            }
+         }
+      }
+
+      /**
+       * Force this listener to chase the last element thrown in the channel.
+       *
+       * @return the number of elements lost by this listener due to the chase
+       */
+      public long chase() {
+         final long sequenceToChase = Math.max(0, this.channel.lvCommittedSequence() - 1);
+         final long lostSequence = sequenceToChase - this.listenedSequence;
+         soLost(lpLost() + lostSequence);
+         this.listenedSequence = sequenceToChase;
+         return lostSequence;
+      }
+
+      /**
+       * The number of elements lost by this listener until the creation of the listened {@link SpMulticastLongChannel}.
+       * This method's accuracy is subject to concurrent modifications happening.
+       *
+       * @return the number of elements lost by this listener
+       */
+      public long lost() {
+         return lvLost();
+      }
+   }
+}

--- a/jctools-experimental/src/main/java/org/jctools/queues/SpMulticastLongChannel.java
+++ b/jctools-experimental/src/main/java/org/jctools/queues/SpMulticastLongChannel.java
@@ -1,0 +1,435 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.queues;
+
+import org.jctools.util.JvmInfo;
+import org.jctools.util.Pow2;
+import org.jctools.util.UnsafeAccess;
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+
+abstract class SpMulticastLongChannelL0Pad {
+
+   long p01, p02, p03, p04, p05, p06, p07;
+   long p10, p11, p12, p13, p14, p15, p16, p17;
+}
+
+abstract class SpMulticastLongChannelSequenceFields extends SpMulticastLongChannelL0Pad {
+
+   private static final long COMMITTED_SEQUENCE_OFFSET;
+
+   static {
+      try {
+         COMMITTED_SEQUENCE_OFFSET = UNSAFE.objectFieldOffset(SpMulticatChannelSequenceFields.class.getDeclaredField("committedSequence"));
+      } catch (NoSuchFieldException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   private volatile long committedSequence;
+
+   protected final long lpCommittedSequence() {
+      return UNSAFE.getLong(this, COMMITTED_SEQUENCE_OFFSET);
+   }
+
+   protected final void soCommittedSequence(long value) {
+      UNSAFE.putOrderedLong(this, COMMITTED_SEQUENCE_OFFSET, value);
+   }
+
+   protected final long lvCommittedSequence() {
+      return UNSAFE.getLongVolatile(this, COMMITTED_SEQUENCE_OFFSET);
+   }
+
+}
+
+abstract class SpMulticastLongChannelL1Pad extends SpMulticastLongChannelSequenceFields {
+
+   long p01, p02, p03, p04, p05, p06, p07;
+   long p10, p11, p12, p13, p14, p15, p16, p17;
+}
+
+/**
+ * A Single-Producer channel backed by a pre-allocated buffer.
+ * It allows enough fast multiple (0 or more) {@link Listener}s to receive the messages.
+ * This is the primitive type specialization of {@link SpMulticastChannel} for long messages.
+ */
+public final class SpMulticastLongChannel extends SpMulticastLongChannelL1Pad {
+
+   protected static final int SEQ_BUFFER_PAD;
+   private static final long ARRAY_BASE;
+   private static final int ELEMENT_SHIFT;
+
+   static {
+      final int scale = UnsafeAccess.UNSAFE.arrayIndexScale(long[].class);
+      if (8 == scale) {
+         ELEMENT_SHIFT = 3;
+      } else {
+         throw new IllegalStateException("Unexpected long[] element size");
+      }
+      // 2 cache lines pad
+      SEQ_BUFFER_PAD = (JvmInfo.CACHE_LINE_SIZE * 2) / scale;
+      // Including the buffer pad in the array base offset
+      ARRAY_BASE = UnsafeAccess.UNSAFE.arrayBaseOffset(long[].class) + (SEQ_BUFFER_PAD * scale);
+   }
+
+   private final long mask;
+   private final int capacity;
+   private final long[] sequenceBuffer;
+   private final long nilValue;
+
+   public SpMulticastLongChannel(int capacity) {
+      this(capacity, -1);
+   }
+
+   public SpMulticastLongChannel(int capacity, long nilValue) {
+      final int actualCapacity = Pow2.roundToPowerOfTwo(capacity * 2);
+      this.mask = actualCapacity - 1;
+      this.capacity = actualCapacity;
+      // pad data on either end with some empty slots.
+      this.sequenceBuffer = new long[actualCapacity + SEQ_BUFFER_PAD * 2];
+      this.nilValue = nilValue;
+   }
+
+   private static long calcSequenceOffset(long index, long mask) {
+      return ARRAY_BASE + ((index & mask) << ELEMENT_SHIFT);
+   }
+
+   private static final void spSequence(long[] buffer, long offset, long e) {
+      UNSAFE.putLong(buffer, offset, e);
+   }
+
+   private static final void soSequence(long[] buffer, long offset, long e) {
+      UNSAFE.putOrderedLong(buffer, offset, e);
+   }
+
+   private static final long lvSequence(long[] buffer, long offset) {
+      return UNSAFE.getLongVolatile(buffer, offset);
+   }
+
+   private static final long lpSequence(long[] buffer, long offset) {
+      return UNSAFE.getLong(buffer, offset);
+   }
+
+   /**
+    * @return the capacity of this channel
+    */
+   public int capacity() {
+      return this.capacity >> 1;
+   }
+
+   /**
+    * @return the chosen value to represent a {@code NULL} message
+    */
+   public long nilValue() {
+      return this.nilValue;
+   }
+
+   /**
+    * The number of elements passed into the channel.
+    * This method's accuracy is subject to concurrent modifications happening.
+    *
+    * @return number of messages thrown in the channel
+    */
+   public long shouts() {
+      return lvCommittedSequence();
+   }
+
+   /**
+    * Inserts the specified element into this channel.
+    * It can be called safely only by one producer thread.
+    *
+    * @param item not {@link #nilValue()}, will throw IAE if it is
+    */
+   public void shout(long item) {
+      if (item == this.nilValue) {
+         throw new IllegalArgumentException("can't shout the nil value!");
+      }
+      final long[] sequenceBuffer = this.sequenceBuffer;
+      final long mask = this.mask;
+      final long sequence = lpCommittedSequence();
+      final long nextSequence = sequence + 1;
+
+      final long sequenceOffset = calcSequenceOffset(sequence << 1, mask);
+      spSequence(sequenceBuffer, sequenceOffset, sequence);
+      final long elementOffset = sequenceOffset + 8;
+      //StoreStore + LoadStore
+      soSequence(sequenceBuffer, elementOffset, item);
+      //StoreStore + LoadStore
+      soSequence(sequenceBuffer, sequenceOffset, nextSequence);
+      //StoreStore + LoadStore
+      soCommittedSequence(nextSequence);
+   }
+
+   /**
+    * Creates an instance of {@link Listener} which can be used for sequential reads from this channel.
+    *
+    * @return a new {@link Listener} instance
+    */
+   public Listener newListener() {
+      return new Listener(this);
+   }
+
+   abstract static class ListenerL0Pad {
+
+      long p01, p02, p03, p04, p05, p06, p07;
+      long p10, p11, p12, p13, p14, p15, p16, p17;
+   }
+
+   abstract static class ListenerLostField extends ListenerL0Pad {
+
+      private static final long LOST_OFFSET;
+
+      static {
+         try {
+            LOST_OFFSET = UNSAFE.objectFieldOffset(ListenerLostField.class.getDeclaredField("lost"));
+         } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+         }
+      }
+
+      private volatile long lost;
+
+      protected final long lpLost() {
+         return UNSAFE.getLong(this, LOST_OFFSET);
+      }
+
+      protected final long lvLost() {
+         return UNSAFE.getLongVolatile(this, LOST_OFFSET);
+      }
+
+      protected final void spLost(long value) {
+         UNSAFE.putLong(this, LOST_OFFSET, value);
+      }
+
+      protected final void soLost(long value) {
+         UNSAFE.putOrderedLong(this, LOST_OFFSET, value);
+      }
+
+   }
+
+   abstract static class ListenerL1Pad extends ListenerLostField {
+
+      long p01, p02, p03, p04, p05, p06, p07;
+      long p10, p11, p12, p13, p14, p15, p16, p17;
+   }
+
+   abstract static class ListenerSequenceField extends ListenerL1Pad {
+
+      protected long listenedSequence;
+
+   }
+
+   abstract static class ListenerL2Pad extends ListenerSequenceField {
+
+      long p01, p02, p03, p04, p05, p06, p07;
+      long p10, p11, p12, p13, p14, p15, p16, p17;
+   }
+
+   /**
+    * It allows sequentially reading messages from a {@link SpMulticastLongChannel}.
+    * It can join the transmission at any point without slowing down the producer.
+    * If it cannot keep up with the transmission loss will be experienced and recorded.
+    */
+   public static final class Listener extends ListenerL2Pad {
+
+      private final SpMulticastLongChannel channel;
+      private final long[] sequenceBuffer;
+      private final int capacity;
+      private final long mask;
+      private final long nilValue;
+      private final int channelCapacity;
+
+      private Listener(SpMulticastLongChannel channel) {
+         this.channel = channel;
+         this.capacity = channel.capacity;
+         this.mask = channel.mask;
+         this.sequenceBuffer = channel.sequenceBuffer;
+         this.nilValue = channel.nilValue;
+         this.channelCapacity = channel.capacity();
+      }
+
+      private static void chase(long listenedSequence, long sequence, long lost, Listener listener) {
+         final long oldListenedSequence = listenedSequence;
+         //if is claimed -> previous sequence is ok
+         //if is committed -> current sequence is ok
+         listenedSequence = sequence - 1;
+         final long lostElements = listenedSequence - oldListenedSequence;
+         lost += lostElements;
+         listener.soLost(lost);
+         listener.listenedSequence = listenedSequence;
+      }
+
+      /**
+       * @see SpMulticastLongChannel#capacity()
+       */
+      public int capacity() {
+         return this.channelCapacity;
+      }
+
+      /**
+       * @see SpMulticastLongChannel#nilValue()
+       */
+      public long nilValue() {
+         return nilValue;
+      }
+
+      /**
+       * Transfer all available items from the channel and hand to consume.
+       * It returns when loss is experienced, with {@link #lost()} incremented by the size of the lost items.
+       *
+       * @return the number of polled elements
+       */
+      public int listen(LongConsumer onMessage) {
+         return listen(onMessage, this.channelCapacity);
+      }
+
+      /**
+       * Transfer up to {@code limit} items from the channel and hand to consume.
+       * It returns when loss is experienced, with {@link #lost()} incremented by the size of the lost items.
+       *
+       * @return the number of polled elements
+       */
+      public int listen(LongConsumer onMessage, int limit) {
+         final long[] sequenceBuffer = this.sequenceBuffer;
+         final long mask = this.mask;
+         long listenedSequence = this.listenedSequence;
+         final long lost = lpLost();
+
+         for (int i = 0; i < limit; i++) {
+            final long sequenceOffset = calcSequenceOffset(listenedSequence << 1, mask);
+            long sequence = lvSequence(sequenceBuffer, sequenceOffset);
+            //LoadLoad + LoadStore
+            final long expectedCommittedSequence = listenedSequence + 1;
+            if (sequence == expectedCommittedSequence) {
+               //listened sequence is committed, can read
+               final long elementOffset = sequenceOffset + 8;
+               final long element = lvSequence(sequenceBuffer, elementOffset);
+               //LoadLoad + LoadStore
+               //TODO a plain load could be enough?
+               sequence = lvSequence(sequenceBuffer, sequenceOffset);
+               //LoadLoad + LoadStore
+               //still valid?
+               if (sequence == expectedCommittedSequence) {
+                  onMessage.accept(element);
+                  //move to the next element
+                  listenedSequence++;
+               } else {
+                  //lost experienced!
+                  chase(listenedSequence, sequence, lost, this);
+                  return i;
+               }
+            } else {
+               if (sequence > expectedCommittedSequence) {
+                  //lost experienced!
+                  chase(listenedSequence, sequence, lost, this);
+                  return i;
+               } else {
+                  //empty!
+                  this.listenedSequence = listenedSequence;
+                  return i;
+               }
+            }
+         }
+         //no loss is experienced!
+         this.listenedSequence = listenedSequence;
+         return limit;
+      }
+
+      /**
+       * Retrieves one item from the channel, if available.
+       * It returns {@link #nilValue()} if there are no new items available or loss is experienced.
+       *
+       * @return the item of the channel or {@link #nilValue()} if loss is experienced or no new items are available
+       */
+      public long listen() {
+         final long[] sequenceBuffer = this.sequenceBuffer;
+         final long mask = this.mask;
+         final long listenedSequence = this.listenedSequence;
+         final long nilValue = this.nilValue;
+         final long lost = lpLost();
+
+         final long sequenceOffset = calcSequenceOffset(listenedSequence << 1, mask);
+         long sequence = lvSequence(sequenceBuffer, sequenceOffset);
+         //LoadLoad + LoadStore
+         final long expectedCommittedSequence = listenedSequence + 1;
+         if (sequence == expectedCommittedSequence) {
+            //listened sequence is committed, can read
+            final long elementOffset = sequenceOffset + 8;
+            final long element = lvSequence(sequenceBuffer, elementOffset);
+            //LoadLoad + LoadStore
+            //TODO a plain load could be enough?
+            sequence = lvSequence(sequenceBuffer, sequenceOffset);
+            //LoadLoad + LoadStore
+            //still valid?
+            if (sequence == expectedCommittedSequence) {
+               //move to the next element
+               this.listenedSequence = listenedSequence + 1;
+               return element;
+            } else {
+               //lost experienced!
+               chase(listenedSequence, sequence, lost, this);
+               return nilValue;
+            }
+         } else {
+            if (sequence > expectedCommittedSequence) {
+               //lost experienced!
+               chase(listenedSequence, sequence, lost, this);
+               return nilValue;
+            } else {
+               //empty!
+               return nilValue;
+            }
+         }
+      }
+
+      /**
+       * Force this listener to chase the last element thrown in the channel.
+       *
+       * @return the number of elements lost by this listener due to the chase
+       */
+      public long chase() {
+         final long sequenceToChase = Math.max(0, this.channel.lvCommittedSequence() - 1);
+         final long lostSequence = sequenceToChase - this.listenedSequence;
+         soLost(lpLost() + lostSequence);
+         this.listenedSequence = sequenceToChase;
+         return lostSequence;
+      }
+
+      /**
+       * The number of elements lost by this listener until the creation of the listened {@link SpMulticastLongChannel}.
+       * This method's accuracy is subject to concurrent modifications happening.
+       *
+       * @return the number of elements lost by this listener
+       */
+      public long lost() {
+         return lvLost();
+      }
+
+      /**
+       * Represents an operation that accepts a single {@code long}-valued argument and
+       * returns no result.
+       */
+      public interface LongConsumer {
+
+         /**
+          * Performs this operation on the given argument.
+          *
+          * @param value the input argument
+          */
+         void accept(long value);
+
+      }
+   }
+}

--- a/jctools-experimental/src/main/resources/org/jctools/channels/ChannelBatchConsumerTemplate.java
+++ b/jctools-experimental/src/main/resources/org/jctools/channels/ChannelBatchConsumerTemplate.java
@@ -1,0 +1,54 @@
+
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+import org.jctools.channels.spsc.SpscChannelConsumer;
+import java.nio.ByteBuffer;
+import org.jctools.channels.ChannelReceiver;
+import java.util.function.LongConsumer;
+
+public class {{className}}
+        extends {{implementationParent}}<{{flyweightInterface}}>
+        implements {{flyweightInterface}} {
+
+    private final LongConsumer readPointer;
+
+    public {{className}}(
+        final ByteBuffer buffer,
+        final int capacity,
+        final int messageSize,
+        final ChannelReceiver<{{flyweightInterface}}> receiver) {
+
+        super(buffer, capacity, messageSize, receiver);
+        this.readPointer = this::onRead;
+    }
+
+    private void onRead(long pointer){
+        this.pointer = pointer;
+        this.receiver.accept(this);
+    }
+
+    public final int read(int limit) {
+        return read(this.readPointer, limit);
+    }
+
+    public final boolean read() {
+        final long pointer = readAcquire();
+        if (pointer == EOF) {
+            return false;
+        }
+        this.pointer = pointer;
+        receiver.accept(this);
+        readRelease(pointer);
+        return true;
+    }
+
+    {{#fields}}
+        public {{type}} get{{name}}() {
+            return UNSAFE.get{{unsafeMethodSuffix}}(pointer + {{fieldOffset}}L);
+        }
+
+        public void set{{name}}({{type}} value) {
+            UNSAFE.put{{unsafeMethodSuffix}}(pointer + {{fieldOffset}}L, value);
+        }
+    {{/fields}}
+
+}

--- a/jctools-experimental/src/test/java/org/jctools/channels/multicast/OffHeapFixedSizeSanityTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/multicast/OffHeapFixedSizeSanityTest.java
@@ -1,0 +1,230 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.channels.multicast;
+
+import java.util.ArrayList;
+import java.util.function.LongConsumer;
+
+import org.jctools.util.JvmInfo;
+import org.jctools.util.UnsafeAccess;
+import org.jctools.util.UnsafeDirectByteBuffer;
+import org.junit.Before;
+import org.junit.Test;
+import sun.nio.ch.DirectBuffer;
+
+import static org.junit.Assert.assertEquals;
+
+public class OffHeapFixedSizeSanityTest {
+
+   private static final int SIZE = 8192 * 2;
+   private static final int MESSAGE_SIZE = 12;
+   private OffHeapFixedMessageSizeAppender appender;
+   private OffHeapFixedMessageSizeTailer tailer;
+
+   @Before
+   public void init() {
+      final int capacity = SIZE;
+      final int bufferSize = ChannelLayout.getRequiredBufferSize(capacity, MESSAGE_SIZE);
+      this.appender = new OffHeapFixedMessageSizeAppender(UnsafeDirectByteBuffer.allocateAlignedByteBuffer(bufferSize, JvmInfo.CACHE_LINE_SIZE), capacity, MESSAGE_SIZE);
+      this.tailer = new OffHeapFixedMessageSizeTailer(this.appender.buffer(), capacity, MESSAGE_SIZE);
+   }
+
+   @Test
+   public void noElementsToListen() {
+      assertEquals(0, appender.shouts());
+      assertEquals(OffHeapFixedMessageSizeTailer.EOF, tailer.readAcquire());
+      assertEquals(0, tailer.lost());
+   }
+
+   @Test
+   public void noElementsToBatchListen() {
+      assertEquals(0, appender.shouts());
+      assertEquals(0, tailer.read(new LongConsumer() {
+         @Override
+         public void accept(long value) {
+
+         }
+      }, Integer.MAX_VALUE));
+      assertEquals(0, tailer.lost());
+   }
+
+   @Test
+   public void chaseWithNoTransmission() {
+      assertEquals(0, appender.shouts());
+      assertEquals(0, tailer.chase());
+      assertEquals(OffHeapFixedMessageSizeTailer.EOF, tailer.readAcquire());
+   }
+
+   @Test
+   public void chaseWithTransmission() {
+      assertEquals(0, appender.shouts());
+      long i = 0;
+      while (i < appender.capacity()) {
+         final long writeSequence = appender.writeAcquire();
+         try {
+            UnsafeAccess.UNSAFE.putLong(appender.messageOffset(writeSequence), i);
+            i++;
+         } finally {
+            appender.writeRelease(writeSequence);
+         }
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, appender.shouts());
+      final long expectedLost = expectedShouts - 1;
+      assertEquals(expectedLost, tailer.chase());
+      final long readSequence = tailer.readAcquire();
+      try {
+         final long value = UnsafeAccess.UNSAFE.getLong(tailer.messageCopyAddress());
+         assertEquals(expectedLost, value);
+      } finally {
+         tailer.readRelease(readSequence);
+      }
+   }
+
+   @Test
+   public void cantBlockProducer() {
+      assertEquals(0, appender.shouts());
+      long i = 0;
+      while (i < appender.capacity() + 1) {
+         final long writeSequence = appender.writeAcquire();
+         try {
+            UnsafeAccess.UNSAFE.putLong(appender.messageOffset(writeSequence), i);
+            i++;
+         } finally {
+            appender.writeRelease(writeSequence);
+         }
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, appender.shouts());
+   }
+
+   @Test
+   public void expectedAppended() {
+      final int values = 10;
+      assertEquals(0, appender.shouts());
+      //fill
+      int i = 0;
+      final long[] addresses = new long[values];
+      while (i < values) {
+         final long writeSequence = appender.writeAcquire();
+         try {
+            addresses[i] = appender.messageOffset(writeSequence);
+            UnsafeAccess.UNSAFE.putLong(appender.messageOffset(writeSequence), i);
+            i++;
+         } finally {
+            appender.writeRelease(writeSequence);
+         }
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, appender.shouts());
+      for(int v = 0;v<addresses.length;v++){
+         assertEquals(v,UnsafeAccess.UNSAFE.getLong(addresses[v]));
+      }
+   }
+
+   @Test
+   public void expectOrderedListen() {
+      assertEquals(0, appender.shouts());
+      //fill
+      long i = 0;
+      while (i < appender.capacity()) {
+         final long writeSequence = appender.writeAcquire();
+         try {
+            UnsafeAccess.UNSAFE.putLong(appender.messageOffset(writeSequence), i);
+            i++;
+         } finally {
+            appender.writeRelease(writeSequence);
+         }
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, appender.shouts());
+      //ordered listen
+      i = 0;
+      long readSequence;
+      while ((readSequence = tailer.readAcquire()) >= 0) {
+         try {
+            final long value = UnsafeAccess.UNSAFE.getLong(tailer.messageCopyAddress());
+            assertEquals(value, i++);
+         } finally {
+            tailer.readRelease(readSequence);
+         }
+      }
+      assertEquals(0, tailer.lost());
+   }
+
+   @Test
+   public void expectBatchListen() {
+      assertEquals(0, appender.shouts());
+      //fill
+      long i = 0;
+      while (i < appender.capacity()) {
+         final long writtenValue = i;
+         final long writeSequence = appender.writeAcquire();
+         try {
+            UnsafeAccess.UNSAFE.putLong(appender.messageOffset(writeSequence), writtenValue);
+            i++;
+         } finally {
+            appender.writeRelease(writeSequence);
+         }
+         assertEquals(1,tailer.read(messageAddress->{
+            final long readValue = UnsafeAccess.UNSAFE.getLong(messageAddress);
+            assertEquals(writtenValue,readValue);
+         }, tailer.capacity()));
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, appender.shouts());
+      assertEquals(0, tailer.lost());
+      assertEquals(0,tailer.read(messageAddress->{}, tailer.capacity()));
+   }
+
+   @Test
+   public void expectOrderedBatchListen() {
+      assertEquals(0, appender.shouts());
+      //fill
+      long i = 0;
+      while (i < appender.capacity()) {
+         final long writeSequence = appender.writeAcquire();
+         try {
+            UnsafeAccess.UNSAFE.putLong(appender.messageOffset(writeSequence), i);
+            i++;
+         } finally {
+            appender.writeRelease(writeSequence);
+         }
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, appender.shouts());
+      //ordered batch listen
+      final ArrayList<Long> values = new ArrayList<>();
+      final int listened = tailer.read(new LongConsumer() {
+         @Override
+         public void accept(long messageAddress) {
+            final long value = UnsafeAccess.UNSAFE.getLong(messageAddress);
+            values.add(value);
+         }
+      }, Integer.MAX_VALUE);
+      assertEquals(tailer.capacity(), listened);
+      assertEquals(0, tailer.lost());
+      i = 0;
+      for (Long value : values) {
+         assertEquals(value.longValue(), i++);
+      }
+   }
+
+
+
+}

--- a/jctools-experimental/src/test/java/org/jctools/queues/MulticastChannelSanityTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/queues/MulticastChannelSanityTest.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.queues;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class MulticastChannelSanityTest {
+
+   private static final int SIZE = 8192 * 2;
+   private SpMulticastChannel<Long> multicastChannel;
+
+   @Before
+   public void init() {
+      this.multicastChannel = new SpMulticastChannel<>(SIZE);
+   }
+
+   @Test
+   public void noElementsToListen() {
+      assertEquals(0, multicastChannel.shouts());
+      final SpMulticastChannel.Listener<Long> listener = multicastChannel.newListener();
+      assertNull(listener.listen());
+      assertEquals(0, listener.lost());
+   }
+
+   @Test
+   public void noElementsToBatchListen() {
+      assertEquals(0, multicastChannel.shouts());
+      final SpMulticastChannel.Listener<Long> listener = multicastChannel.newListener();
+      assertEquals(0, listener.listen(new MessagePassingQueue.Consumer<Long>() {
+         @Override
+         public void accept(Long e) {
+
+         }
+      }), Integer.MAX_VALUE);
+      assertEquals(0, listener.lost());
+   }
+
+   @Test
+   public void chaseWithNoTransmission() {
+      assertEquals(0, multicastChannel.shouts());
+      final SpMulticastChannel.Listener<Long> listener = multicastChannel.newListener();
+      assertEquals(0, listener.chase());
+      assertEquals(null, listener.listen());
+   }
+
+   @Test
+   public void chaseWithTransmission() {
+      assertEquals(0, multicastChannel.shouts());
+      long i = 0;
+      while (i < multicastChannel.capacity()) {
+         multicastChannel.shout(i);
+         i++;
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, multicastChannel.shouts());
+
+      final SpMulticastChannel.Listener<Long> listener = multicastChannel.newListener();
+      final long expectedLost = expectedShouts - 1;
+      assertEquals(expectedLost, listener.chase());
+      assertEquals(expectedLost, listener.listen().longValue());
+   }
+
+   @Test
+   public void cantBlockProducer() {
+      assertEquals(0, multicastChannel.shouts());
+      long i = 0;
+      while (i < multicastChannel.capacity() + 1) {
+         multicastChannel.shout(i);
+         i++;
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, multicastChannel.shouts());
+   }
+
+   @Test
+   public void expectOrderedListen() {
+      assertEquals(0, multicastChannel.shouts());
+      //fill
+      long i = 0;
+      while (i < multicastChannel.capacity()) {
+         multicastChannel.shout(i);
+         i++;
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, multicastChannel.shouts());
+      //ordered listen
+      final SpMulticastChannel.Listener<Long> listener = multicastChannel.newListener();
+      i = 0;
+      Long e;
+      while ((e = listener.listen()) != null) {
+         assertEquals(e.longValue(), i++);
+      }
+      assertEquals(0, listener.lost());
+   }
+
+   @Test
+   public void expectOrderedBatchListen() {
+      assertEquals(0, multicastChannel.shouts());
+      //fill
+      long i = 0;
+      while (i < multicastChannel.capacity()) {
+         multicastChannel.shout(i);
+         i++;
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, multicastChannel.shouts());
+      //ordered batch listen
+      final SpMulticastChannel.Listener<Long> listener = multicastChannel.newListener();
+      final ArrayList<Long> values = new ArrayList<>();
+      final int listened = listener.listen(new MessagePassingQueue.Consumer<Long>() {
+         @Override
+         public void accept(Long e) {
+            values.add(e);
+         }
+      }, Integer.MAX_VALUE);
+      assertEquals(multicastChannel.capacity(), listened);
+      assertEquals(0, listener.lost());
+      i = 0;
+      for (Long value : values) {
+         assertEquals(value.longValue(), i++);
+      }
+   }
+}

--- a/jctools-experimental/src/test/java/org/jctools/queues/MulticastLongChannelSanityTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/queues/MulticastLongChannelSanityTest.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jctools.queues;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MulticastLongChannelSanityTest {
+
+   private static final int SIZE = 8192 * 2;
+   private SpMulticastLongChannel multicastChannel;
+
+   @Before
+   public void init() {
+      this.multicastChannel = new SpMulticastLongChannel(SIZE);
+   }
+
+   @Test
+   public void noElementsToListen() {
+      assertEquals(0, multicastChannel.shouts());
+      final SpMulticastLongChannel.Listener listener = multicastChannel.newListener();
+      assertEquals(listener.listen(), listener.nilValue());
+      assertEquals(0, listener.lost());
+   }
+
+   @Test
+   public void noElementsToBatchListen() {
+      assertEquals(0, multicastChannel.shouts());
+      final SpMulticastLongChannel.Listener listener = multicastChannel.newListener();
+      assertEquals(0, listener.listen(new SpMulticastLongChannel.Listener.LongConsumer() {
+         @Override
+         public void accept(long value) {
+
+         }
+      }, Integer.MAX_VALUE));
+      assertEquals(0, listener.lost());
+   }
+
+   @Test
+   public void chaseWithNoTransmission() {
+      assertEquals(0, multicastChannel.shouts());
+      final SpMulticastLongChannel.Listener listener = multicastChannel.newListener();
+      assertEquals(0, listener.chase());
+      assertEquals(listener.nilValue(), listener.listen());
+   }
+
+   @Test
+   public void chaseWithTransmission() {
+      assertEquals(0, multicastChannel.shouts());
+      long i = 0;
+      while (i < multicastChannel.capacity()) {
+         multicastChannel.shout(i);
+         i++;
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, multicastChannel.shouts());
+
+      final SpMulticastLongChannel.Listener listener = multicastChannel.newListener();
+      final long expectedLost = expectedShouts - 1;
+      assertEquals(expectedLost, listener.chase());
+      assertEquals(expectedLost, listener.listen());
+   }
+
+   @Test
+   public void cantBlockProducer() {
+      assertEquals(0, multicastChannel.shouts());
+      long i = 0;
+      while (i < multicastChannel.capacity() + 1) {
+         multicastChannel.shout(i);
+         i++;
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, multicastChannel.shouts());
+   }
+
+   @Test
+   public void expectOrderedListen() {
+      assertEquals(0, multicastChannel.shouts());
+      //fill
+      long i = 0;
+      while (i < multicastChannel.capacity()) {
+         multicastChannel.shout(i);
+         i++;
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, multicastChannel.shouts());
+      //ordered listen
+      final SpMulticastLongChannel.Listener listener = multicastChannel.newListener();
+      i = 0;
+      long e;
+      while ((e = listener.listen()) != listener.nilValue()) {
+         assertEquals(e, i++);
+      }
+      assertEquals(0, listener.lost());
+   }
+
+   @Test
+   public void expectOrderedBatchListen() {
+      assertEquals(0, multicastChannel.shouts());
+      //fill
+      long i = 0;
+      while (i < multicastChannel.capacity()) {
+         multicastChannel.shout(i);
+         i++;
+      }
+      long expectedShouts = i;
+      assertEquals(expectedShouts, multicastChannel.shouts());
+      //ordered batch listen
+      final SpMulticastLongChannel.Listener listener = multicastChannel.newListener();
+      final ArrayList<Long> values = new ArrayList<>();
+      final int listened = listener.listen(new SpMulticastLongChannel.Listener.LongConsumer() {
+         @Override
+         public void accept(long value) {
+            values.add(value);
+         }
+      }, Integer.MAX_VALUE);
+      assertEquals(multicastChannel.capacity(), listened);
+      assertEquals(0, listener.lost());
+      i = 0;
+      for (Long value : values) {
+         assertEquals(value.longValue(), i++);
+      }
+   }
+}


### PR DESCRIPTION
It includes 3 different flavours of the same data structure ie a single producer multicast channel:
a ring buffer that allows the producer to overwrite the published content without being slowed down by the consumers.
The consumers, like the LMAX Disruptor's handlers are able to read every produced message, but can join the transmission in any moment, reading the messages or simply chasing the latest produced message without reading it.
Each time a consumer will attempt to chase or join a transmission it could experience losses if not fast enough: in that case it will maintain the count of the overall lost messages.

The 3 flavours are:
1) A primitive (long) one (build as a base-line to be tested against the third flavour with LongValue flyweight)
2) An heap base one (maybe a freak experiment, considering that the messages will remain in the ring buffer until they will be overwritten)
3) An off-heap one (that will join the list of the off heap fixed size message channels)

Are provided sanity tests (that mimic the others of the already present data structures) and micro-benchmarks (hand-rolled and JMH based one).

The algorithm is based on the same idea of the FastFlow queue ie using an indicator for each message to store the state of the producer while approaching to the message slot (ready to be written/just written + how many times it is happened) but the consumers will read(-acquire) it just to verify if the message content is no longer valid and to know how many messages they have lost.