### PR TITLE
Atomic version of the SpscLinkedArrayQueue -  sans UnSafe usages

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/IndexedQueueSizeUtil.java
+++ b/jctools-core/src/main/java/org/jctools/queues/IndexedQueueSizeUtil.java
@@ -13,13 +13,13 @@
  */
 package org.jctools.queues;
 
-final class IndexedQueueSizeUtil {
+public final class IndexedQueueSizeUtil {
     private IndexedQueueSizeUtil(){}
-    protected interface IndexedQueue {
+    public interface IndexedQueue {
         long lvConsumerIndex();
         long lvProducerIndex();
     }
-    static int size(IndexedQueue iq) {
+    public static int size(IndexedQueue iq) {
         /*
          * It is possible for a thread to be interrupted or reschedule between the read of the producer and
          * consumer indices, therefore protection is required to ensure size is within valid range. In the
@@ -47,7 +47,7 @@ final class IndexedQueueSizeUtil {
         }
     }
 
-    static boolean isEmpty(IndexedQueue iq) {
+    public static boolean isEmpty(IndexedQueue iq) {
         // Order matters!
         // Loading consumer before producer allows for producer increments after consumer index is read.
         // This ensures this method is conservative in it's estimate. Note that as this is an MPMC there is

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicBaseSpscLinkedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicBaseSpscLinkedArrayQueue.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import org.jctools.queues.IndexedQueueSizeUtil;
+import org.jctools.queues.IndexedQueueSizeUtil.IndexedQueue;
+import org.jctools.queues.QueueProgressIndicators;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+abstract class AtomicBaseSpscLinkedArrayQueuePrePad<E> extends AbstractQueue<E> {
+    long p0, p1, p2, p3, p4, p5, p6, p7;
+    long p10, p11, p12, p13, p14, p15;
+    //  p16, p17; drop 2 longs, the cold fields act as buffer
+}
+
+abstract class AtomicBaseSpscLinkedArrayQueueConsumerColdFields<E> extends AtomicBaseSpscLinkedArrayQueuePrePad<E> {
+    protected long consumerMask;
+    protected AtomicReferenceArray<E> consumerBuffer;
+}
+
+abstract class AtomicBaseSpscLinkedArrayQueueConsumerField<E> extends AtomicBaseSpscLinkedArrayQueueConsumerColdFields<E> {
+    static final AtomicLongFieldUpdater<AtomicBaseSpscLinkedArrayQueueConsumerField> C_INDEX_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(AtomicBaseSpscLinkedArrayQueueConsumerField.class, "consumerIndex");
+    protected volatile long consumerIndex;
+}
+
+abstract class AtomicBaseSpscLinkedArrayQueueL2Pad<E> extends AtomicBaseSpscLinkedArrayQueueConsumerField<E> {
+    long p0, p1, p2, p3, p4, p5, p6, p7;
+    long p10, p11, p12, p13, p14, p15, p16, p17;
+}
+
+abstract class AtomicBaseSpscLinkedArrayQueueProducerFields<E> extends AtomicBaseSpscLinkedArrayQueueL2Pad<E> {
+    static final AtomicLongFieldUpdater<AtomicBaseSpscLinkedArrayQueueProducerFields> P_INDEX_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(AtomicBaseSpscLinkedArrayQueueProducerFields.class, "producerIndex");
+    protected volatile long producerIndex;
+
+}
+
+abstract class AtomicBaseSpscLinkedArrayQueueProducerColdFields<E> extends AtomicBaseSpscLinkedArrayQueueProducerFields<E> {
+    protected long producerBufferLimit;
+    protected long producerMask; // fixed for chunked and unbounded
+
+    protected AtomicReferenceArray<E> producerBuffer;
+}
+
+abstract class AtomicBaseSpscLinkedArrayQueue<E> extends AtomicBaseSpscLinkedArrayQueueProducerColdFields<E>
+        implements QueueProgressIndicators, IndexedQueue {
+
+    protected static final Object JUMP = new Object();
+
+    protected final void soProducerIndex(long v) {
+        P_INDEX_UPDATER.lazySet(this, v);
+    }
+
+    protected final void soConsumerIndex(long v) {
+        C_INDEX_UPDATER.lazySet(this, v);
+    }
+
+    public final long lvProducerIndex() {
+        return producerIndex;
+    }
+
+    public final long lvConsumerIndex() {
+        return consumerIndex;
+    }
+
+    protected static <E> AtomicReferenceArray<E> allocate(int capacity) {
+        return new AtomicReferenceArray<E>(capacity);
+    }
+
+    @Override
+    public final Iterator<E> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getName();
+    }
+
+    @Override
+    public long currentProducerIndex() {
+        return lvProducerIndex();
+    }
+
+    @Override
+    public long currentConsumerIndex() {
+        return lvConsumerIndex();
+    }
+
+
+    protected final void soNext(AtomicReferenceArray<E> curr, AtomicReferenceArray<E> next) {
+        soElement(curr, nextArrayOffset(curr), next);
+    }
+
+    private void soElement(AtomicReferenceArray curr, int i, Object e) {
+        curr.lazySet(i, e);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected final AtomicReferenceArray<E> lvNextArrayAndUnlink(AtomicReferenceArray curr) {
+        final int nextArrayOffset = nextArrayOffset(curr);
+        final AtomicReferenceArray<E> nextBuffer = (AtomicReferenceArray<E>) curr.get(nextArrayOffset);
+        // prevent GC nepotism
+        soElement(curr, nextArrayOffset, null);
+        return nextBuffer;
+    }
+
+    private int nextArrayOffset(AtomicReferenceArray<E> curr) {
+        return (curr.length() - 1);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single producer thread use only.
+     */
+    @Override
+    public boolean offer(final E e) {
+        // Objects.requireNonNull(e);
+        if (null == e) {
+            throw new NullPointerException();
+        }
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<E> buffer = producerBuffer;
+        final long index = producerIndex;
+        final long mask = producerMask;
+        final int offset = calcElementOffset(index, mask);
+        // expected hot path
+        if (index < producerBufferLimit) {
+            writeToQueue(buffer, e, index, offset);
+            return true;
+        }
+        return offerColdPath(buffer, mask, e, index, offset);
+    }
+
+    protected abstract boolean offerColdPath(AtomicReferenceArray<E> buffer, long mask, E e, long pIndex, int offset);
+
+    protected final void linkOldToNew(final long currIndex, final AtomicReferenceArray<E> oldBuffer, final int offset,
+            final AtomicReferenceArray<E> newBuffer, final int offsetInNew, final E e) {
+        soElement(newBuffer, offsetInNew, e);// StoreStore
+        // link to next buffer and add next indicator as element of old buffer
+        soNext(oldBuffer, newBuffer);
+        soElement(oldBuffer, offset, JUMP);
+        // index is visible after elements (isEmpty/poll ordering)
+        soProducerIndex(currIndex + 1);// this ensures atomic write of long on 32bit platforms
+    }
+
+    protected final void writeToQueue(final AtomicReferenceArray<E> buffer, final E e, final long index, final int offset) {
+        soElement(buffer, offset, e);// StoreStore
+        soProducerIndex(index + 1);// this ensures atomic write of long on 32bit platforms
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single consumer thread use only.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public E poll() {
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<E> buffer = consumerBuffer;
+        final long index = consumerIndex;
+        final long mask = consumerMask;
+        final int offset = calcElementOffset(index, mask);
+        final Object e = lvElement(buffer, offset);// LoadLoad
+        boolean isNextBuffer = e == JUMP;
+        if (null != e && !isNextBuffer) {
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
+            soElement(buffer, offset, null);
+            return (E) e;
+        } else if (isNextBuffer) {
+            return newBufferPoll(buffer, index);
+        }
+
+        return null;
+    }
+
+    protected E lvElement(AtomicReferenceArray<E> buffer, int offset) {
+        return buffer.get(offset);
+    }
+
+    protected static int calcElementOffset(long index, long mask) {
+        return (int) (index & mask);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single consumer thread use only.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public E peek() {
+        final AtomicReferenceArray<E> buffer = consumerBuffer;
+        final long index = consumerIndex;
+        final long mask = consumerMask;
+        final int offset = calcElementOffset(index, mask);
+        final Object e = lvElement(buffer, offset);// LoadLoad
+        if (e == JUMP) {
+            return newBufferPeek(buffer, index);
+        }
+
+        return (E) e;
+    }
+
+    private E newBufferPeek(AtomicReferenceArray<E> buffer, final long index) {
+        AtomicReferenceArray<E> nextBuffer = lvNextArrayAndUnlink(buffer);
+        consumerBuffer = nextBuffer;
+        final long newMask = nextBuffer.length() - 2;
+        consumerMask = newMask;
+        final int offsetInNew = calcElementOffset(index, newMask);
+        return lvElement(nextBuffer, offsetInNew);// LoadLoad
+    }
+
+    private E newBufferPoll(AtomicReferenceArray<E> buffer, final long index) {
+        AtomicReferenceArray<E> nextBuffer = lvNextArrayAndUnlink(buffer);
+        consumerBuffer = nextBuffer;
+        final long newMask = nextBuffer.length() - 2;
+        consumerMask = newMask;
+        final int offsetInNew = calcElementOffset(index, newMask);
+        final E n = lvElement(nextBuffer, offsetInNew);// LoadLoad
+        if (null == n) {
+            throw new IllegalStateException("new buffer must have at least one element");
+        } else {
+            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
+            soElement(nextBuffer, offsetInNew, null);// StoreStore
+            return n;
+        }
+    }
+
+    @Override
+    public final int size() {
+        return IndexedQueueSizeUtil.size(this);
+    }
+
+    @Override
+    public final boolean isEmpty() {
+        return IndexedQueueSizeUtil.isEmpty(this);
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicSpscChunkedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicSpscChunkedArrayQueue.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import org.jctools.util.Pow2;
+import org.jctools.util.RangeUtil;
+
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+public class AtomicSpscChunkedArrayQueue<E> extends AtomicBaseSpscLinkedArrayQueue<E> {
+    private int maxQueueCapacity;
+    private long producerQueueLimit;
+
+    public AtomicSpscChunkedArrayQueue(final int capacity) {
+        this(Math.max(8, Pow2.roundToPowerOfTwo(capacity / 8)), capacity);
+    }
+
+    public AtomicSpscChunkedArrayQueue(final int chunkSize, final int capacity) {
+        RangeUtil.checkGreaterThanOrEqual(capacity, 16, "capacity");
+        // minimal chunk size of eight makes sure minimal lookahead step is 2
+        RangeUtil.checkGreaterThanOrEqual(chunkSize, 8, "chunkSize");
+
+        maxQueueCapacity = Pow2.roundToPowerOfTwo(capacity);
+        int chunkCapacity = Pow2.roundToPowerOfTwo(chunkSize);
+        RangeUtil.checkLessThan(chunkCapacity, maxQueueCapacity, "chunkCapacity");
+
+        long mask = chunkCapacity - 1;
+        // need extra element to point at next array
+        AtomicReferenceArray<E> buffer = allocate(chunkCapacity + 1);
+        producerBuffer = buffer;
+        producerMask = mask;
+        consumerBuffer = buffer;
+        consumerMask = mask;
+        producerBufferLimit = mask - 1; // we know it's all empty to start with
+        producerQueueLimit = maxQueueCapacity;
+        soProducerIndex(0L);// serves as a StoreStore barrier to support correct publication
+    }
+
+    @Override
+    protected final boolean offerColdPath(AtomicReferenceArray<E> buffer, long mask, E e, long pIndex, int offset) {
+        // use a fixed lookahead step based on buffer capacity
+        final long lookAheadStep = (mask + 1) / 4;
+        long pBufferLimit = pIndex + lookAheadStep;
+
+        long pQueueLimit = producerQueueLimit;
+
+        if (pIndex >= pQueueLimit) {
+            // we tested against a potentially out of date queue limit, refresh it
+            long cIndex = lvConsumerIndex();
+            producerQueueLimit = pQueueLimit = cIndex + maxQueueCapacity;
+            // if we're full we're full
+            if (pIndex >= pQueueLimit) {
+                return false;
+            }
+        }
+        // if buffer limit is after queue limit we use queue limit. We need to handle overflow so
+        // cannot use Math.min
+        if (pBufferLimit - pQueueLimit > 0) {
+            pBufferLimit = pQueueLimit;
+        }
+
+        // go around the buffer or add a new buffer
+        if (pBufferLimit > pIndex + 1 && // there's sufficient room in buffer/queue to use pBufferLimit
+                null == lvElement(buffer, calcElementOffset(pBufferLimit, mask))) {
+            producerBufferLimit = pBufferLimit - 1; // joy, there's plenty of room
+            writeToQueue(buffer, e, pIndex, offset);
+        }
+        else if (null == lvElement(buffer, calcElementOffset(pIndex + 1, mask))) { // buffer is not full
+            writeToQueue(buffer, e, pIndex, offset);
+        }
+        else {
+            // we got one slot left to write into, and we are not full. Need to link new buffer.
+            // allocate new buffer of same length
+            final AtomicReferenceArray<E> newBuffer = allocate((int)(mask + 2));
+            producerBuffer = newBuffer;
+
+            linkOldToNew(pIndex, buffer, offset, newBuffer, offset, e);
+        }
+        return true;
+    }
+
+}

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscLinkedArrayQueueSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscLinkedArrayQueueSanityTest.java
@@ -1,0 +1,32 @@
+package org.jctools.queues.atomic;
+
+import org.jctools.queues.QueueSanityTest;
+import org.jctools.queues.SpscChunkedArrayQueue;
+import org.jctools.queues.spec.ConcurrentQueueSpec;
+import org.jctools.queues.spec.Ordering;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Queue;
+
+@RunWith(Parameterized.class)
+public class AtomicSpscLinkedArrayQueueSanityTest extends QueueSanityTest {
+    @Parameterized.Parameters
+    public static Collection<Object[]> parameters() {
+        ArrayList<Object[]> list = new ArrayList<Object[]>();
+        list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new AtomicSpscChunkedArrayQueue<Integer>(64, SIZE)));
+        //list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(64, SIZE)));
+        //list.add(makeQueue(1, 1, 0, Ordering.FIFO, new AtomicSpscUnboundedArrayQueue<Integer>(16)));
+        // minimal sizes
+        list.add(makeQueue(1, 1, 16, Ordering.FIFO, new AtomicSpscChunkedArrayQueue<Integer>(8, 16)));
+        //list.add(makeQueue(1, 1, 16, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(8, 16)));
+        return list;
+    }
+
+    public AtomicSpscLinkedArrayQueueSanityTest(ConcurrentQueueSpec spec, Queue<Integer> queue) {
+        super(spec, queue);
+    }
+
+}


### PR DESCRIPTION
`AtomicSpscChunkedArrayQueue`: created an `Atomic` version of the `SpscLinkedArrayQueue` - sans `UnSafe` usages, replicated relevant tests and used Atomic data types wherever needed

Pending `AtomicSpscGrowableArrayQueue` and `AtomicSpscUnboundedArrayQueue`

Partially fixes #165 