### PR TITLE
Reconvert spsc unbounded atomic array queue

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
@@ -13,15 +13,15 @@
  */
 package org.jctools.queues;
 
+import org.jctools.util.Pow2;
+import org.jctools.util.UnsafeRefArrayAccess;
+
 import static org.jctools.util.UnsafeAccess.UNSAFE;
 import static org.jctools.util.UnsafeRefArrayAccess.lvElement;
 import static org.jctools.util.UnsafeRefArrayAccess.soElement;
 
-import org.jctools.util.Pow2;
-import org.jctools.util.UnsafeRefArrayAccess;
-
 abstract class SpscArrayQueueColdField<E> extends ConcurrentCircularArrayQueue<E> {
-    static final int MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
+    public static final int MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
     protected final int lookAheadStep;
     public SpscArrayQueueColdField(int capacity) {
         super(capacity);

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicSpscGrowableArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicSpscGrowableArrayQueue.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues.atomic;
+
+import org.jctools.queues.SpscArrayQueue;
+import org.jctools.util.Pow2;
+import org.jctools.util.RangeUtil;
+
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+public class AtomicSpscGrowableArrayQueue<E> extends AtomicBaseSpscLinkedArrayQueue<E> {
+    private int maxQueueCapacity; // ignored by the unbounded implementation
+    private long lookAheadStep;// ignored by the unbounded implementation
+    public AtomicSpscGrowableArrayQueue(final int capacity) {
+        this(Math.max(8, Pow2.roundToPowerOfTwo(capacity / 8)), capacity);
+    }
+
+    public AtomicSpscGrowableArrayQueue(final int chunkSize, final int capacity) {
+        RangeUtil.checkGreaterThanOrEqual(capacity, 16, "capacity");
+        // minimal chunk size of eight makes sure minimal lookahead step is 2
+        RangeUtil.checkGreaterThanOrEqual(chunkSize, 8, "chunkSize");
+
+        maxQueueCapacity = Pow2.roundToPowerOfTwo(capacity);
+        int chunkCapacity = Pow2.roundToPowerOfTwo(chunkSize);
+        RangeUtil.checkLessThan(chunkCapacity, maxQueueCapacity, "chunkCapacity");
+
+        long mask = chunkCapacity - 1;
+        // need extra element to point at next array
+        AtomicReferenceArray<E> buffer = allocate(chunkCapacity + 1);
+        producerBuffer = buffer;
+        producerMask = mask;
+        consumerBuffer = buffer;
+        consumerMask = mask;
+        producerBufferLimit = mask - 1; // we know it's all empty to start with
+        adjustLookAheadStep(chunkCapacity);
+        soProducerIndex(0L);// serves as a StoreStore barrier to support correct publication
+    }
+
+    protected final boolean offerColdPath(final AtomicReferenceArray<E> buffer, final long mask, final E e, final long index,
+                                          final int offset) {
+        final long lookAheadStep = this.lookAheadStep;
+        // normal case, go around the buffer or resize if full (unless we hit max capacity)
+        if (lookAheadStep > 0) {
+            int lookAheadElementOffset = calcElementOffset(index + lookAheadStep, mask);
+            // Try and look ahead a number of elements so we don't have to do this all the time
+            if (null == lvElement(buffer, lookAheadElementOffset)) {
+                producerBufferLimit = index + lookAheadStep - 1; // joy, there's plenty of room
+                writeToQueue(buffer, e, index, offset);
+                return true;
+            }
+            // we're at max capacity, can use up last element
+            final int maxCapacity = maxQueueCapacity;
+            if (mask + 1 == maxCapacity) {
+                if (null == lvElement(buffer, offset)) {
+                    writeToQueue(buffer, e, index, offset);
+                    return true;
+                }
+                // we're full and can't grow
+                return false;
+            }
+            // not at max capacity, so must allow extra slot for next buffer pointer
+            if (null == lvElement(buffer, calcElementOffset(index + 1, mask))) { // buffer is not full
+                writeToQueue(buffer, e, index, offset);
+            } else {
+                // allocate new buffer of same length
+                final AtomicReferenceArray<E> newBuffer = allocate((int) (2*(mask +1) + 1));
+
+                producerBuffer = newBuffer;
+                producerMask = newBuffer.length() - 2;
+
+                final int offsetInNew = calcElementOffset(index, producerMask);
+                linkOldToNew(index, buffer, offset, newBuffer, offsetInNew, e);
+                int newCapacity = (int) (producerMask + 1);
+                if (newCapacity == maxCapacity) {
+                    long currConsumerIndex = lvConsumerIndex();
+                    // use lookAheadStep to store the consumer distance from final buffer
+                    this.lookAheadStep = -(index - currConsumerIndex);
+                    producerBufferLimit = currConsumerIndex + maxCapacity - 1;
+                } else {
+                    producerBufferLimit = index + producerMask - 1;
+                    adjustLookAheadStep(newCapacity);
+                }
+            }
+            return true;
+        }
+        // the step is negative (or zero) in the period between allocating the max sized buffer and the
+        // consumer starting on it
+        else {
+            final long prevElementsInOtherBuffers = -lookAheadStep;
+            // until the consumer starts using the current buffer we need to check consumer index to
+            // verify size
+            long currConsumerIndex = lvConsumerIndex();
+            int size = (int) (index - currConsumerIndex);
+            int maxCapacity = (int) mask+1; // we're on max capacity or we wouldn't be here
+            if (size == maxCapacity) {
+                // consumer index has not changed since adjusting the lookAhead index, we're full
+                return false;
+            }
+            // if consumerIndex progressed enough so that current size indicates it is on same buffer
+            long firstIndexInCurrentBuffer = producerBufferLimit - maxCapacity + prevElementsInOtherBuffers;
+            if (currConsumerIndex >= firstIndexInCurrentBuffer) {
+                // job done, we've now settled into our final state
+                adjustLookAheadStep(maxCapacity);
+            }
+            // consumer is still on some other buffer
+            else {
+                // how many elements out of buffer?
+                this.lookAheadStep = (int) (currConsumerIndex - firstIndexInCurrentBuffer);
+            }
+            producerBufferLimit = currConsumerIndex + maxCapacity;
+            writeToQueue(buffer, e, index, offset);
+            return true;
+        }
+    }
+
+
+    private void adjustLookAheadStep(int capacity) {
+        lookAheadStep = Math.min(capacity / 4, SpscArrayQueue.MAX_LOOK_AHEAD_STEP);
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/BaseSpscLinkedAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/BaseSpscLinkedAtomicArrayQueue.java
@@ -22,43 +22,43 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-abstract class AtomicBaseSpscLinkedArrayQueuePrePad<E> extends AbstractQueue<E> {
+abstract class BaseSpscLinkedAtomicArrayQueuePrePad<E> extends AbstractQueue<E> {
     long p0, p1, p2, p3, p4, p5, p6, p7;
     long p10, p11, p12, p13, p14, p15;
     //  p16, p17; drop 2 longs, the cold fields act as buffer
 }
 
-abstract class AtomicBaseSpscLinkedArrayQueueConsumerColdFields<E> extends AtomicBaseSpscLinkedArrayQueuePrePad<E> {
+abstract class BaseSpscLinkedAtomicArrayQueueConsumerColdFields<E> extends BaseSpscLinkedAtomicArrayQueuePrePad<E> {
     protected long consumerMask;
     protected AtomicReferenceArray<E> consumerBuffer;
 }
 
-abstract class AtomicBaseSpscLinkedArrayQueueConsumerField<E> extends AtomicBaseSpscLinkedArrayQueueConsumerColdFields<E> {
-    static final AtomicLongFieldUpdater<AtomicBaseSpscLinkedArrayQueueConsumerField> C_INDEX_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(AtomicBaseSpscLinkedArrayQueueConsumerField.class, "consumerIndex");
+abstract class BaseSpscLinkedAtomicArrayQueueConsumerField<E> extends BaseSpscLinkedAtomicArrayQueueConsumerColdFields<E> {
+    static final AtomicLongFieldUpdater<BaseSpscLinkedAtomicArrayQueueConsumerField> C_INDEX_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(BaseSpscLinkedAtomicArrayQueueConsumerField.class, "consumerIndex");
     protected volatile long consumerIndex;
 }
 
-abstract class AtomicBaseSpscLinkedArrayQueueL2Pad<E> extends AtomicBaseSpscLinkedArrayQueueConsumerField<E> {
+abstract class BaseSpscLinkedAtomicArrayQueueL2Pad<E> extends BaseSpscLinkedAtomicArrayQueueConsumerField<E> {
     long p0, p1, p2, p3, p4, p5, p6, p7;
     long p10, p11, p12, p13, p14, p15, p16, p17;
 }
 
-abstract class AtomicBaseSpscLinkedArrayQueueProducerFields<E> extends AtomicBaseSpscLinkedArrayQueueL2Pad<E> {
-    static final AtomicLongFieldUpdater<AtomicBaseSpscLinkedArrayQueueProducerFields> P_INDEX_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(AtomicBaseSpscLinkedArrayQueueProducerFields.class, "producerIndex");
+abstract class BaseSpscLinkedAtomicArrayQueueProducerFields<E> extends BaseSpscLinkedAtomicArrayQueueL2Pad<E> {
+    static final AtomicLongFieldUpdater<BaseSpscLinkedAtomicArrayQueueProducerFields> P_INDEX_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(BaseSpscLinkedAtomicArrayQueueProducerFields.class, "producerIndex");
     protected volatile long producerIndex;
 
 }
 
-abstract class AtomicBaseSpscLinkedArrayQueueProducerColdFields<E> extends AtomicBaseSpscLinkedArrayQueueProducerFields<E> {
+abstract class BaseSpscLinkedAtomicArrayQueueProducerColdFields<E> extends BaseSpscLinkedAtomicArrayQueueProducerFields<E> {
     protected long producerBufferLimit;
     protected long producerMask; // fixed for chunked and unbounded
 
     protected AtomicReferenceArray<E> producerBuffer;
 }
 
-abstract class AtomicBaseSpscLinkedArrayQueue<E> extends AtomicBaseSpscLinkedArrayQueueProducerColdFields<E>
+abstract class BaseSpscLinkedAtomicArrayQueue<E> extends BaseSpscLinkedAtomicArrayQueueProducerColdFields<E>
         implements QueueProgressIndicators, IndexedQueue {
 
     protected static final Object JUMP = new Object();

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscChunkedAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscChunkedAtomicArrayQueue.java
@@ -18,15 +18,15 @@ import org.jctools.util.RangeUtil;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-public class AtomicSpscChunkedArrayQueue<E> extends AtomicBaseSpscLinkedArrayQueue<E> {
+public class SpscChunkedAtomicArrayQueue<E> extends AtomicBaseSpscLinkedArrayQueue<E> {
     private int maxQueueCapacity;
     private long producerQueueLimit;
 
-    public AtomicSpscChunkedArrayQueue(final int capacity) {
+    public SpscChunkedAtomicArrayQueue(final int capacity) {
         this(Math.max(8, Pow2.roundToPowerOfTwo(capacity / 8)), capacity);
     }
 
-    public AtomicSpscChunkedArrayQueue(final int chunkSize, final int capacity) {
+    public SpscChunkedAtomicArrayQueue(final int chunkSize, final int capacity) {
         RangeUtil.checkGreaterThanOrEqual(capacity, 16, "capacity");
         // minimal chunk size of eight makes sure minimal lookahead step is 2
         RangeUtil.checkGreaterThanOrEqual(chunkSize, 8, "chunkSize");

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscChunkedAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscChunkedAtomicArrayQueue.java
@@ -18,7 +18,7 @@ import org.jctools.util.RangeUtil;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-public class SpscChunkedAtomicArrayQueue<E> extends AtomicBaseSpscLinkedArrayQueue<E> {
+public class SpscChunkedAtomicArrayQueue<E> extends BaseSpscLinkedAtomicArrayQueue<E> {
     private int maxQueueCapacity;
     private long producerQueueLimit;
 

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscGrowableAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscGrowableAtomicArrayQueue.java
@@ -19,14 +19,14 @@ import org.jctools.util.RangeUtil;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-public class AtomicSpscGrowableArrayQueue<E> extends AtomicBaseSpscLinkedArrayQueue<E> {
+public class SpscGrowableAtomicArrayQueue<E> extends AtomicBaseSpscLinkedArrayQueue<E> {
     private int maxQueueCapacity; // ignored by the unbounded implementation
     private long lookAheadStep;// ignored by the unbounded implementation
-    public AtomicSpscGrowableArrayQueue(final int capacity) {
+    public SpscGrowableAtomicArrayQueue(final int capacity) {
         this(Math.max(8, Pow2.roundToPowerOfTwo(capacity / 8)), capacity);
     }
 
-    public AtomicSpscGrowableArrayQueue(final int chunkSize, final int capacity) {
+    public SpscGrowableAtomicArrayQueue(final int chunkSize, final int capacity) {
         RangeUtil.checkGreaterThanOrEqual(capacity, 16, "capacity");
         // minimal chunk size of eight makes sure minimal lookahead step is 2
         RangeUtil.checkGreaterThanOrEqual(chunkSize, 8, "chunkSize");

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscGrowableAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscGrowableAtomicArrayQueue.java
@@ -19,7 +19,7 @@ import org.jctools.util.RangeUtil;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-public class SpscGrowableAtomicArrayQueue<E> extends AtomicBaseSpscLinkedArrayQueue<E> {
+public class SpscGrowableAtomicArrayQueue<E> extends BaseSpscLinkedAtomicArrayQueue<E> {
     private int maxQueueCapacity; // ignored by the unbounded implementation
     private long lookAheadStep;// ignored by the unbounded implementation
     public SpscGrowableAtomicArrayQueue(final int capacity) {

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscUnboundedAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscUnboundedAtomicArrayQueue.java
@@ -13,245 +13,48 @@
  */
 package org.jctools.queues.atomic;
 
-import java.util.AbstractQueue;
-import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReferenceArray;
-
-import org.jctools.queues.QueueProgressIndicators;
 import org.jctools.util.Pow2;
 
-public class SpscUnboundedAtomicArrayQueue<E> extends AbstractQueue<E> implements QueueProgressIndicators{
-    static final int MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
-    protected final AtomicLong producerIndex;
-    protected int producerLookAheadStep;
-    protected long producerLookAhead;
-    protected int producerMask;
-    protected AtomicReferenceArray<Object> producerBuffer;
-    protected int consumerMask;
-    protected AtomicReferenceArray<Object> consumerBuffer;
-    protected final AtomicLong consumerIndex;
-    private static final Object HAS_NEXT = new Object();
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+public class SpscUnboundedAtomicArrayQueue<E> extends BaseSpscLinkedAtomicArrayQueue<E> {
 
     public SpscUnboundedAtomicArrayQueue(final int chunkSize) {
-    	int p2ChunkSize = Math.max(Pow2.roundToPowerOfTwo(chunkSize), 16);
-
-        int mask = p2ChunkSize - 1;
-        AtomicReferenceArray<Object> buffer = new AtomicReferenceArray<Object>(p2ChunkSize + 1);
+        int chunkCapacity = Math.max(Pow2.roundToPowerOfTwo(chunkSize), 16);
+        long mask = chunkCapacity - 1;
+        AtomicReferenceArray<E> buffer = allocate(chunkCapacity + 1);
         producerBuffer = buffer;
         producerMask = mask;
-        adjustLookAheadStep(p2ChunkSize);
         consumerBuffer = buffer;
         consumerMask = mask;
-        producerLookAhead = mask - 1; // we know it's all empty to start with
-        producerIndex = new AtomicLong();
-        consumerIndex = new AtomicLong();
+        producerBufferLimit = mask - 1; // we know it's all empty to start with
         soProducerIndex(0L);
     }
 
     @Override
-    public final Iterator<E> iterator() {
-        throw new UnsupportedOperationException();
-    }
+    protected boolean offerColdPath(AtomicReferenceArray<E> buffer, long mask, E e, long pIndex, int offset) {
+        // use a fixed lookahead step based on buffer capacity
+        final long lookAheadStep = (mask + 1) / 4;
+        long pBufferLimit = pIndex + lookAheadStep;
 
-
-    @Override
-    public String toString() {
-        return this.getClass().getName();
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * This implementation is correct for single producer thread use only.
-     */
-    @Override
-    public final boolean offer(final E e) {
-        if (null == e) {
-            throw new NullPointerException();
+        // go around the buffer or add a new buffer
+        if (null == lvElement(buffer, calcElementOffset(pBufferLimit, mask))) {
+            producerBufferLimit = pBufferLimit - 1; // joy, there's plenty of room
+            writeToQueue(buffer, e, pIndex, offset);
         }
-        // local load of field to avoid repeated loads after volatile reads
-        final AtomicReferenceArray<Object> buffer = producerBuffer;
-        final long index = lpProducerIndex();
-        final int mask = producerMask;
-        final int offset = calcWrappedOffset(index, mask);
-        if (index < producerLookAhead) {
-            return writeToQueue(buffer, e, index, offset);
-        } else {
-            final int lookAheadStep = producerLookAheadStep;
-            // go around the buffer or resize if full (unless we hit max capacity)
-            int lookAheadElementOffset = calcWrappedOffset(index + lookAheadStep, mask);
-            if (null == lvElement(buffer, lookAheadElementOffset)) {// LoadLoad
-                producerLookAhead = index + lookAheadStep - 1; // joy, there's plenty of room
-                return writeToQueue(buffer, e, index, offset);
-            } else if (null == lvElement(buffer, calcWrappedOffset(index + 1, mask))) { // buffer is not full
-                return writeToQueue(buffer, e, index, offset);
-            } else {
-                resize(buffer, index, offset, e, mask); // add a buffer and link old to new
-                return true;
-            }
+        else if (null == lvElement(buffer, calcElementOffset(pIndex + 1, mask))) { // buffer is not full
+            writeToQueue(buffer, e, pIndex, offset);
         }
-    }
+        else {
+            // we got one slot left to write into, and we are not full. Need to link new buffer.
+            // allocate new buffer of same length
+            final AtomicReferenceArray<E> newBuffer =  allocate((int)(mask + 2));
+            producerBuffer = newBuffer;
+            producerBufferLimit = pIndex + mask - 1;
 
-    private boolean writeToQueue(final AtomicReferenceArray<Object> buffer, final E e, final long index, final int offset) {
-        soElement(buffer, offset, e);// StoreStore
-        soProducerIndex(index + 1);// this ensures atomic write of long on 32bit platforms
+            linkOldToNew(pIndex, buffer, offset, newBuffer, offset, e);
+        }
         return true;
     }
 
-    private void resize(final AtomicReferenceArray<Object> oldBuffer, final long currIndex, final int offset, final E e,
-            final long mask) {
-        final int capacity = oldBuffer.length();
-        final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<Object>(capacity);
-        producerBuffer = newBuffer;
-        producerLookAhead = currIndex + mask - 1;
-        soElement(newBuffer, offset, e);// StoreStore
-        soNext(oldBuffer, newBuffer);
-        soElement(oldBuffer, offset, HAS_NEXT); // new buffer is visible after element is inserted
-        soProducerIndex(currIndex + 1);// this ensures correctness on 32bit platforms
-    }
-
-    private void soNext(AtomicReferenceArray<Object> curr, AtomicReferenceArray<Object> next) {
-        soElement(curr, calcDirectOffset(curr.length() - 1), next);
-    }
-    @SuppressWarnings("unchecked")
-    private AtomicReferenceArray<Object> lvNext(AtomicReferenceArray<Object> curr) {
-        return (AtomicReferenceArray<Object>)lvElement(curr, calcDirectOffset(curr.length() - 1));
-    }
-    /**
-     * {@inheritDoc}
-     * <p>
-     * This implementation is correct for single consumer thread use only.
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    public final E poll() {
-        // local load of field to avoid repeated loads after volatile reads
-        final AtomicReferenceArray<Object> buffer = consumerBuffer;
-        final long index = lpConsumerIndex();
-        final int mask = consumerMask;
-        final int offset = calcWrappedOffset(index, mask);
-        final Object e = lvElement(buffer, offset);// LoadLoad
-        boolean isNextBuffer = e == HAS_NEXT;
-        if (null != e && !isNextBuffer) {
-            soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
-            soElement(buffer, offset, null);// StoreStore
-            return (E) e;
-        } else if (isNextBuffer) {
-            return newBufferPoll(buffer, index, mask);
-        }
-
-        return null;
-    }
-
-    @SuppressWarnings("unchecked")
-    private E newBufferPoll(AtomicReferenceArray<Object> buffer, final long index, final int mask) {
-        AtomicReferenceArray<Object> nextBuffer = lvNext(buffer);
-        consumerBuffer = nextBuffer;
-        final int offsetInNew = calcWrappedOffset(index, mask);
-        final E n = (E) lvElement(nextBuffer, offsetInNew);// LoadLoad
-        soConsumerIndex(index + 1);// this ensures correctness on 32bit platforms
-        soElement(nextBuffer, offsetInNew, null);// StoreStore
-        // prevent extended retention if the buffer is in old gen and the nextBuffer is in young gen
-        soNext(buffer, null);
-        return n;
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * This implementation is correct for single consumer thread use only.
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    public final E peek() {
-        final AtomicReferenceArray<Object> buffer = consumerBuffer;
-        final long index = lpConsumerIndex();
-        final int mask = consumerMask;
-        final int offset = calcWrappedOffset(index, mask);
-        final Object e = lvElement(buffer, offset);// LoadLoad
-        if (e == HAS_NEXT) {
-            return newBufferPeek(lvNext(buffer), index, mask);
-        }
-
-        return (E) e;
-    }
-
-    @SuppressWarnings("unchecked")
-    private E newBufferPeek(AtomicReferenceArray<Object> nextBuffer, final long index, final int mask) {
-        consumerBuffer = nextBuffer;
-        final int offsetInNew = calcWrappedOffset(index, mask);
-        return (E) lvElement(nextBuffer, offsetInNew);// LoadLoad
-    }
-
-    @Override
-    public final int size() {
-        /*
-         * It is possible for a thread to be interrupted or reschedule between the read of the producer and
-         * consumer indices, therefore protection is required to ensure size is within valid range. In the
-         * event of concurrent polls/offers to this method the size is OVER estimated as we read consumer
-         * index BEFORE the producer index.
-         */
-        long after = lvConsumerIndex();
-        while (true) {
-            final long before = after;
-            final long currentProducerIndex = lvProducerIndex();
-            after = lvConsumerIndex();
-            if (before == after) {
-                return (int) (currentProducerIndex - after);
-            }
-        }
-    }
-
-    private void adjustLookAheadStep(int capacity) {
-        producerLookAheadStep = Math.min(capacity / 4, MAX_LOOK_AHEAD_STEP);
-    }
-
-    private long lvProducerIndex() {
-        return producerIndex.get();
-    }
-
-    private long lvConsumerIndex() {
-        return consumerIndex.get();
-    }
-
-    private long lpProducerIndex() {
-        return producerIndex.get();
-    }
-
-    private long lpConsumerIndex() {
-        return consumerIndex.get();
-    }
-
-    private void soProducerIndex(long v) {
-        producerIndex.lazySet(v);
-    }
-
-    private void soConsumerIndex(long v) {
-        consumerIndex.lazySet(v);
-    }
-
-    private static int calcWrappedOffset(long index, int mask) {
-        return calcDirectOffset((int)index & mask);
-    }
-    private static int calcDirectOffset(int index) {
-        return index;
-    }
-    private static void soElement(AtomicReferenceArray<Object> buffer, int offset, Object e) {
-        buffer.lazySet(offset, e);
-    }
-
-    private static <E> Object lvElement(AtomicReferenceArray<Object> buffer, int offset) {
-        return buffer.get(offset);
-    }
-
-    @Override
-    public long currentProducerIndex() {
-        return lvProducerIndex();
-    }
-
-    @Override
-    public long currentConsumerIndex() {
-        return lvConsumerIndex();
-    }
 }

--- a/jctools-core/src/test/java/org/jctools/queues/QueueSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/QueueSanityTest.java
@@ -1,7 +1,6 @@
 package org.jctools.queues;
 
 import org.jctools.queues.atomic.AtomicQueueFactory;
-import org.jctools.queues.atomic.SpscUnboundedAtomicArrayQueue;
 import org.jctools.queues.spec.ConcurrentQueueSpec;
 import org.jctools.queues.spec.Ordering;
 import org.jctools.queues.spec.Preference;

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicQueueSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicQueueSanityTest.java
@@ -1,16 +1,16 @@
 package org.jctools.queues.atomic;
 
-import static org.jctools.util.JvmInfo.CPUs;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Queue;
-
 import org.jctools.queues.QueueSanityTest;
 import org.jctools.queues.spec.ConcurrentQueueSpec;
 import org.jctools.queues.spec.Ordering;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Queue;
+
+import static org.jctools.util.JvmInfo.CPUs;
 
 @RunWith(Parameterized.class)
 

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscLinkedArrayQueueSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscLinkedArrayQueueSanityTest.java
@@ -16,11 +16,11 @@ public class AtomicSpscLinkedArrayQueueSanityTest extends QueueSanityTest {
     public static Collection<Object[]> parameters() {
         ArrayList<Object[]> list = new ArrayList<Object[]>();
         list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new SpscChunkedAtomicArrayQueue<Integer>(64, SIZE)));
-        list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(64, SIZE)));
+        list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new SpscGrowableAtomicArrayQueue<Integer>(64, SIZE)));
         list.add(makeQueue(1, 1, 0, Ordering.FIFO, new SpscUnboundedAtomicArrayQueue<Integer>(16)));
         // minimal sizes
         list.add(makeQueue(1, 1, 16, Ordering.FIFO, new SpscChunkedAtomicArrayQueue<Integer>(8, 16)));
-        list.add(makeQueue(1, 1, 16, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(8, 16)));
+        list.add(makeQueue(1, 1, 16, Ordering.FIFO, new SpscGrowableAtomicArrayQueue<Integer>(8, 16)));
         return list;
     }
 

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscLinkedArrayQueueSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscLinkedArrayQueueSanityTest.java
@@ -1,7 +1,6 @@
 package org.jctools.queues.atomic;
 
 import org.jctools.queues.QueueSanityTest;
-import org.jctools.queues.SpscChunkedArrayQueue;
 import org.jctools.queues.spec.ConcurrentQueueSpec;
 import org.jctools.queues.spec.Ordering;
 import org.junit.runner.RunWith;
@@ -17,11 +16,11 @@ public class AtomicSpscLinkedArrayQueueSanityTest extends QueueSanityTest {
     public static Collection<Object[]> parameters() {
         ArrayList<Object[]> list = new ArrayList<Object[]>();
         list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new AtomicSpscChunkedArrayQueue<Integer>(64, SIZE)));
-        //list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(64, SIZE)));
+        list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(64, SIZE)));
         //list.add(makeQueue(1, 1, 0, Ordering.FIFO, new AtomicSpscUnboundedArrayQueue<Integer>(16)));
         // minimal sizes
         list.add(makeQueue(1, 1, 16, Ordering.FIFO, new AtomicSpscChunkedArrayQueue<Integer>(8, 16)));
-        //list.add(makeQueue(1, 1, 16, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(8, 16)));
+        list.add(makeQueue(1, 1, 16, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(8, 16)));
         return list;
     }
 

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscLinkedArrayQueueSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscLinkedArrayQueueSanityTest.java
@@ -15,11 +15,11 @@ public class AtomicSpscLinkedArrayQueueSanityTest extends QueueSanityTest {
     @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         ArrayList<Object[]> list = new ArrayList<Object[]>();
-        list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new AtomicSpscChunkedArrayQueue<Integer>(64, SIZE)));
+        list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new SpscChunkedAtomicArrayQueue<Integer>(64, SIZE)));
         list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(64, SIZE)));
         list.add(makeQueue(1, 1, 0, Ordering.FIFO, new SpscUnboundedAtomicArrayQueue<Integer>(16)));
         // minimal sizes
-        list.add(makeQueue(1, 1, 16, Ordering.FIFO, new AtomicSpscChunkedArrayQueue<Integer>(8, 16)));
+        list.add(makeQueue(1, 1, 16, Ordering.FIFO, new SpscChunkedAtomicArrayQueue<Integer>(8, 16)));
         list.add(makeQueue(1, 1, 16, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(8, 16)));
         return list;
     }

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscLinkedArrayQueueSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/AtomicSpscLinkedArrayQueueSanityTest.java
@@ -17,7 +17,7 @@ public class AtomicSpscLinkedArrayQueueSanityTest extends QueueSanityTest {
         ArrayList<Object[]> list = new ArrayList<Object[]>();
         list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new AtomicSpscChunkedArrayQueue<Integer>(64, SIZE)));
         list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(64, SIZE)));
-        //list.add(makeQueue(1, 1, 0, Ordering.FIFO, new AtomicSpscUnboundedArrayQueue<Integer>(16)));
+        list.add(makeQueue(1, 1, 0, Ordering.FIFO, new SpscUnboundedAtomicArrayQueue<Integer>(16)));
         // minimal sizes
         list.add(makeQueue(1, 1, 16, Ordering.FIFO, new AtomicSpscChunkedArrayQueue<Integer>(8, 16)));
         list.add(makeQueue(1, 1, 16, Ordering.FIFO, new AtomicSpscGrowableArrayQueue<Integer>(8, 16)));


### PR DESCRIPTION
- rename classes 
- reconvert SPSC unbounded array queue to SPSC unbounded atomic array queue 

Fully fixes #165 