### PR TITLE
Implement remove(Object) for single consumer linked atomic queues

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpscLinkedAtomicQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpscLinkedAtomicQueue.java
@@ -114,4 +114,13 @@ public final class MpscLinkedAtomicQueue<E> extends BaseLinkedAtomicQueue<E> {
         return null;
     }
 
+    @Override
+    LinkedQueueAtomicNode<E> getNextConsumerNode(LinkedQueueAtomicNode<E> currConsumerNode) {
+        LinkedQueueAtomicNode<E> nextNode = currConsumerNode.lvNext();
+        if (nextNode == null && currConsumerNode != lvProducerNode()) {
+            // spin, we are no longer wait free
+            while ((nextNode = currConsumerNode.lvNext()) == null);
+        }
+        return nextNode;
+    }
 }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscLinkedAtomicQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscLinkedAtomicQueue.java
@@ -98,4 +98,8 @@ public final class SpscLinkedAtomicQueue<E> extends BaseLinkedAtomicQueue<E> {
         }
     }
 
+    @Override
+    LinkedQueueAtomicNode<E> getNextConsumerNode(LinkedQueueAtomicNode<E> currConsumerNode) {
+        return currConsumerNode.lvNext();
+    }
 }

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/MpscLinkedAtomicQueueTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/MpscLinkedAtomicQueueTest.java
@@ -1,0 +1,10 @@
+package org.jctools.queues.atomic;
+
+import java.util.Queue;
+
+public class MpscLinkedAtomicQueueTest extends ScLinkedAtomicQueueTest {
+    @Override
+    protected Queue<Integer> newQueue() {
+        return new MpscLinkedAtomicQueue<>();
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/ScLinkedAtomicQueueTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/ScLinkedAtomicQueueTest.java
@@ -1,0 +1,161 @@
+package org.jctools.queues.atomic;
+
+import org.junit.Test;
+
+import java.util.Queue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public abstract class ScLinkedAtomicQueueTest {
+    protected abstract Queue<Integer> newQueue();
+
+    private static <T> void assertQueueEmpty(Queue<T> queue) {
+        assertNull(queue.peek());
+        assertNull(queue.poll());
+        assertTrue(queue.isEmpty());
+        assertEquals(0, queue.size());
+    }
+
+    private void removeSimple(int removeValue, int expectedFirst, int expectedSecond) throws InterruptedException {
+        final Queue<Integer> queue = newQueue();
+        Thread t = new Thread() {
+            @Override
+            public void run() {
+                queue.offer(1);
+                queue.offer(2);
+                queue.offer(3);
+            }
+        };
+
+        assertQueueEmpty(queue);
+
+        t.start();
+
+        while (queue.size() < 3) {
+            Thread.yield();
+        }
+
+        assertTrue(queue.remove(removeValue));
+        // Try to remove again, just to ensure pointers are updated as expected.
+        assertFalse(queue.remove(removeValue));
+        assertFalse(queue.isEmpty());
+        assertEquals(2, queue.size());
+
+        assertEquals(expectedFirst, queue.poll().intValue());
+        assertEquals(expectedSecond, queue.poll().intValue());
+        assertQueueEmpty(queue);
+
+        t.join();
+    }
+
+    @Test
+    public void removeConsumerNode() throws InterruptedException {
+        removeSimple(1, 2, 3);
+    }
+
+    @Test
+    public void removeInteriorNode() throws InterruptedException {
+        removeSimple(2, 1, 3);
+    }
+
+    @Test
+    public void removeProducerNode() throws InterruptedException {
+        removeSimple(3, 1, 2);
+    }
+
+    @Test
+    public void removeFailsWhenExpected() throws InterruptedException {
+        final Queue<Integer> queue = newQueue();
+        Thread t = new Thread() {
+            @Override
+            public void run() {
+                queue.offer(1);
+                queue.offer(2);
+                queue.offer(3);
+            }
+        };
+
+        assertQueueEmpty(queue);
+
+        t.start();
+
+        while (queue.size() < 3) {
+            Thread.yield();
+        }
+
+        // Remove an element which doesn't exist.
+        assertFalse(queue.remove(4));
+        assertFalse(queue.remove(4));
+        assertFalse(queue.isEmpty());
+        assertEquals(3, queue.size());
+
+        // Verify that none of the links have been modified.
+        assertEquals(1, queue.poll().intValue());
+        assertEquals(2, queue.poll().intValue());
+        assertEquals(3, queue.poll().intValue());
+        assertQueueEmpty(queue);
+
+        t.join();
+    }
+
+    @Test
+    public void removeStressTest() throws InterruptedException {
+        // The test maybe racy ... just repeat it numerous times to increase the likely hood we will catch a failure.
+        for (int i = 0; i < 10000; ++i) {
+            final Queue<Integer> queue = newQueue();
+            Thread t = new Thread() {
+                @Override
+                public void run() {
+                    queue.offer(1);
+                    queue.offer(2);
+                    queue.offer(3);
+                    queue.offer(4);
+                    queue.offer(5);
+                    queue.offer(6);
+                }
+            };
+
+            assertQueueEmpty(queue);
+
+            t.start();
+
+            while (queue.size() < 3) {
+                Thread.yield();
+            }
+
+            // Remove from the middle
+            assertTrue(queue.remove(2));
+            assertFalse(queue.remove(2));
+
+            // Remove from the front
+            assertTrue(queue.remove(1));
+            assertFalse(queue.remove(1));
+
+            assertTrue(queue.remove(3));
+            assertFalse(queue.remove(3));
+
+            while (queue.size() != 3) {
+                Thread.yield();
+            }
+
+            // Remove from the end
+            assertTrue(queue.remove(6));
+            assertFalse(queue.remove(6));
+
+            // Remove from the middle
+            assertTrue(queue.remove(4));
+            assertFalse(queue.remove(4));
+
+            // Remove the last element
+            assertTrue(queue.remove(5));
+            assertFalse(queue.remove(5));
+
+            assertQueueEmpty(queue);
+
+            t.join();
+        }
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/SpscLinkedAtomicQueueTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/SpscLinkedAtomicQueueTest.java
@@ -1,0 +1,10 @@
+package org.jctools.queues.atomic;
+
+import java.util.Queue;
+
+public class SpscLinkedAtomicQueueTest extends ScLinkedAtomicQueueTest {
+    @Override
+    protected Queue<Integer> newQueue() {
+        return new SpscLinkedAtomicQueue<>();
+    }
+}


### PR DESCRIPTION
Motivation:
Queue implementations in JCTools generally do not support removal of elements. This feature may be necessary to prevent object leaks by retaining references to objects in long lived queues.

Modifications:
- BaseLinkedAtomicQueue implements boolean remove(Object) API in accordance with the JDK's queue interface
- MpscLinkedAtomicQueue and SpscLinkedAtomicQueue override the necessary getNext method used by the remove method

Result:
Single consumer linked atomic queue implementations support remove(Object)