### PR TITLE
Homogenize atomic queues

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/MpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpscArrayQueue.java
@@ -46,6 +46,7 @@ abstract class MpscArrayQueueTailField<E> extends MpscArrayQueueL1Pad<E> {
         super(capacity);
     }
 
+    @Override
     public final long lvProducerIndex() {
         return producerIndex;
     }
@@ -125,6 +126,7 @@ abstract class MpscArrayQueueConsumerField<E> extends MpscArrayQueueL2Pad<E> {
         return consumerIndex;
     }
 
+    @Override
     public final long lvConsumerIndex() {
         return UNSAFE.getLongVolatile(this, C_INDEX_OFFSET);
     }
@@ -147,7 +149,7 @@ abstract class MpscArrayQueueConsumerField<E> extends MpscArrayQueueL2Pad<E> {
  *
  * @param <E>
  */
-public class MpscArrayQueue<E> extends MpscArrayQueueConsumerField<E>implements QueueProgressIndicators {
+public class MpscArrayQueue<E> extends MpscArrayQueueConsumerField<E> implements QueueProgressIndicators {
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
 

--- a/jctools-core/src/main/java/org/jctools/queues/SpmcArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpmcArrayQueue.java
@@ -207,7 +207,6 @@ public class SpmcArrayQueue<E> extends SpmcArrayQueueL3Pad<E> implements QueuePr
         return e;
     }
 
-
 	@Override
 	public boolean relaxedOffer(E e) {
 		if (null == e) {

--- a/jctools-core/src/main/java/org/jctools/queues/SpmcArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpmcArrayQueue.java
@@ -30,12 +30,12 @@ abstract class SpmcArrayQueueL1Pad<E> extends ConcurrentCircularArrayQueue<E> {
     }
 }
 
-abstract class SpmcArrayQueueProducerField<E> extends SpmcArrayQueueL1Pad<E> {
+abstract class SpmcArrayQueueProducerIndexField<E> extends SpmcArrayQueueL1Pad<E> {
     protected final static long P_INDEX_OFFSET;
     static {
         try {
             P_INDEX_OFFSET =
-                    UNSAFE.objectFieldOffset(SpmcArrayQueueProducerField.class.getDeclaredField("producerIndex"));
+                    UNSAFE.objectFieldOffset(SpmcArrayQueueProducerIndexField.class.getDeclaredField("producerIndex"));
         } catch (NoSuchFieldException e) {
             throw new RuntimeException(e);
         }
@@ -50,12 +50,12 @@ abstract class SpmcArrayQueueProducerField<E> extends SpmcArrayQueueL1Pad<E> {
         UNSAFE.putOrderedLong(this, P_INDEX_OFFSET, v);
     }
 
-    public SpmcArrayQueueProducerField(int capacity) {
+    public SpmcArrayQueueProducerIndexField(int capacity) {
         super(capacity);
     }
 }
 
-abstract class SpmcArrayQueueL2Pad<E> extends SpmcArrayQueueProducerField<E> {
+abstract class SpmcArrayQueueL2Pad<E> extends SpmcArrayQueueProducerIndexField<E> {
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
 
@@ -64,19 +64,19 @@ abstract class SpmcArrayQueueL2Pad<E> extends SpmcArrayQueueProducerField<E> {
     }
 }
 
-abstract class SpmcArrayQueueConsumerField<E> extends SpmcArrayQueueL2Pad<E> {
+abstract class SpmcArrayQueueConsumerIndexField<E> extends SpmcArrayQueueL2Pad<E> {
     protected final static long C_INDEX_OFFSET;
     static {
         try {
             C_INDEX_OFFSET =
-                    UNSAFE.objectFieldOffset(SpmcArrayQueueConsumerField.class.getDeclaredField("consumerIndex"));
+                    UNSAFE.objectFieldOffset(SpmcArrayQueueConsumerIndexField.class.getDeclaredField("consumerIndex"));
         } catch (NoSuchFieldException e) {
             throw new RuntimeException(e);
         }
     }
     private volatile long consumerIndex;
 
-    public SpmcArrayQueueConsumerField(int capacity) {
+    public SpmcArrayQueueConsumerIndexField(int capacity) {
         super(capacity);
     }
 
@@ -89,7 +89,7 @@ abstract class SpmcArrayQueueConsumerField<E> extends SpmcArrayQueueL2Pad<E> {
     }
 }
 
-abstract class SpmcArrayQueueMidPad<E> extends SpmcArrayQueueConsumerField<E> {
+abstract class SpmcArrayQueueMidPad<E> extends SpmcArrayQueueConsumerIndexField<E> {
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
 
@@ -126,6 +126,7 @@ abstract class SpmcArrayQueueL3Pad<E> extends SpmcArrayQueueProducerIndexCacheFi
 }
 
 public class SpmcArrayQueue<E> extends SpmcArrayQueueL3Pad<E> implements QueueProgressIndicators {
+    
     public SpmcArrayQueue(final int capacity) {
         super(capacity);
     }

--- a/jctools-core/src/main/java/org/jctools/queues/SpmcArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpmcArrayQueue.java
@@ -17,6 +17,7 @@ import static org.jctools.util.UnsafeAccess.UNSAFE;
 import static org.jctools.util.UnsafeRefArrayAccess.lpElement;
 import static org.jctools.util.UnsafeRefArrayAccess.lvElement;
 import static org.jctools.util.UnsafeRefArrayAccess.soElement;
+import static org.jctools.util.UnsafeRefArrayAccess.spElement;
 
 import org.jctools.util.UnsafeRefArrayAccess;
 
@@ -138,7 +139,7 @@ public class SpmcArrayQueue<E> extends SpmcArrayQueueL3Pad<E> implements QueuePr
         final long mask = this.mask;
         final long currProducerIndex = lvProducerIndex();
         final long offset = calcElementOffset(currProducerIndex, mask);
-        if (null != UnsafeRefArrayAccess.lvElement(buffer, offset)) {
+        if (null != lvElement(buffer, offset)) {
             long size = currProducerIndex - lvConsumerIndex();
 
             if(size > mask) {
@@ -146,10 +147,10 @@ public class SpmcArrayQueue<E> extends SpmcArrayQueueL3Pad<E> implements QueuePr
             }
             else {
                 // spin wait for slot to clear, buggers wait freedom
-                while(null != UnsafeRefArrayAccess.lvElement(buffer, offset));
+                while(null != lvElement(buffer, offset));
             }
         }
-        UnsafeRefArrayAccess.spElement(buffer, offset, e);
+        spElement(buffer, offset, e);
         // single producer, so store ordered is valid. It is also required to correctly publish the element
         // and for the consumers to pick up the tail value.
         soProducerIndex(currProducerIndex + 1);

--- a/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
@@ -13,8 +13,6 @@
  */
 package org.jctools.queues;
 
-import org.jctools.util.UnsafeRefArrayAccess;
-
 import static org.jctools.util.UnsafeAccess.UNSAFE;
 import static org.jctools.util.UnsafeRefArrayAccess.lvElement;
 import static org.jctools.util.UnsafeRefArrayAccess.soElement;
@@ -96,9 +94,10 @@ abstract class SpscArrayQueueConsumerField<E> extends SpscArrayQueueL2Pad<E> {
  *
  * @param <E>
  */
-public class SpscArrayQueue<E> extends SpscArrayQueueConsumerField<E>  implements QueueProgressIndicators {
+public class SpscArrayQueue<E> extends SpscArrayQueueConsumerField<E> implements QueueProgressIndicators {
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
+    
     public SpscArrayQueue(final int capacity) {
         super(Math.max(capacity, 4));
     }
@@ -170,14 +169,14 @@ public class SpscArrayQueue<E> extends SpscArrayQueueConsumerField<E>  implement
      */
     @Override
     public E peek() {
-        return UnsafeRefArrayAccess.lvElement(buffer, calcElementOffset(consumerIndex));
+        return lvElement(buffer, calcElementOffset(consumerIndex));
     }
 
-    private void soProducerIndex(long newIndex) {
+    private void soProducerIndex(final long newIndex) {
         UNSAFE.putOrderedLong(this, P_INDEX_OFFSET, newIndex);
     }
 
-    private void soConsumerIndex(long newIndex) {
+    private void soConsumerIndex(final long newIndex) {
         UNSAFE.putOrderedLong(this, C_INDEX_OFFSET, newIndex);
     }
 

--- a/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
@@ -182,10 +182,12 @@ public class SpscArrayQueue<E> extends SpscArrayQueueConsumerField<E>  implement
         UNSAFE.putOrderedLong(this, C_INDEX_OFFSET, v);
     }
 
+    @Override
     public final long lvProducerIndex() {
         return UNSAFE.getLongVolatile(this, P_INDEX_OFFSET);
     }
 
+    @Override
     public final long lvConsumerIndex() {
         return UNSAFE.getLongVolatile(this, C_INDEX_OFFSET);
     }

--- a/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
@@ -50,6 +50,16 @@ abstract class SpscArrayQueueProducerFields<E> extends SpscArrayQueueL1Pad<E> {
     public SpscArrayQueueProducerFields(int capacity) {
         super(capacity);
     }
+    
+    @Override
+    public final long lvProducerIndex() {
+        return UNSAFE.getLongVolatile(this, P_INDEX_OFFSET);
+    }
+
+    protected final void soProducerIndex(final long newIndex) {
+        UNSAFE.putOrderedLong(this, P_INDEX_OFFSET, newIndex);
+    }
+    
 }
 
 abstract class SpscArrayQueueL2Pad<E> extends SpscArrayQueueProducerFields<E> {
@@ -74,6 +84,14 @@ abstract class SpscArrayQueueConsumerField<E> extends SpscArrayQueueL2Pad<E> {
     }
     public SpscArrayQueueConsumerField(int capacity) {
         super(capacity);
+    }
+
+    public final long lvConsumerIndex() {
+        return UNSAFE.getLongVolatile(this, C_INDEX_OFFSET);
+    }
+    
+    protected final void soConsumerIndex(final long newIndex) {
+        UNSAFE.putOrderedLong(this, C_INDEX_OFFSET, newIndex);
     }
 }
 
@@ -172,23 +190,7 @@ public class SpscArrayQueue<E> extends SpscArrayQueueConsumerField<E> implements
         return lvElement(buffer, calcElementOffset(consumerIndex));
     }
 
-    private void soProducerIndex(final long newIndex) {
-        UNSAFE.putOrderedLong(this, P_INDEX_OFFSET, newIndex);
-    }
 
-    private void soConsumerIndex(final long newIndex) {
-        UNSAFE.putOrderedLong(this, C_INDEX_OFFSET, newIndex);
-    }
-
-    @Override
-    public final long lvProducerIndex() {
-        return UNSAFE.getLongVolatile(this, P_INDEX_OFFSET);
-    }
-
-    @Override
-    public final long lvConsumerIndex() {
-        return UNSAFE.getLongVolatile(this, C_INDEX_OFFSET);
-    }
 
     @Override
     public boolean relaxedOffer(final E message) {

--- a/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
@@ -135,7 +135,7 @@ public class SpscArrayQueue<E> extends SpscArrayQueueConsumerField<E>  implement
         if (null == lvElement(buffer, calcElementOffset(producerIndex + lookAheadStep, mask))) {// LoadLoad
             producerLimit = producerIndex + lookAheadStep;
         }
-        else{
+        else {
             final long offset = calcElementOffset(producerIndex, mask);
             if (null != lvElement(buffer, offset)){
                 return false;

--- a/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
@@ -13,7 +13,6 @@
  */
 package org.jctools.queues;
 
-import org.jctools.util.Pow2;
 import org.jctools.util.UnsafeRefArrayAccess;
 
 import static org.jctools.util.UnsafeAccess.UNSAFE;
@@ -25,7 +24,7 @@ abstract class SpscArrayQueueColdField<E> extends ConcurrentCircularArrayQueue<E
     protected final int lookAheadStep;
     public SpscArrayQueueColdField(int capacity) {
         super(capacity);
-        lookAheadStep = Math.min(capacity/4, MAX_LOOK_AHEAD_STEP);
+        lookAheadStep = Math.min(capacity() / 4, MAX_LOOK_AHEAD_STEP);
     }
 }
 abstract class SpscArrayQueueL1Pad<E> extends SpscArrayQueueColdField<E> {
@@ -101,7 +100,7 @@ public class SpscArrayQueue<E> extends SpscArrayQueueConsumerField<E>  implement
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
     public SpscArrayQueue(final int capacity) {
-        super(Math.max(Pow2.roundToPowerOfTwo(capacity), 4));
+        super(Math.max(capacity, 4));
     }
 
     /**

--- a/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
@@ -174,12 +174,12 @@ public class SpscArrayQueue<E> extends SpscArrayQueueConsumerField<E>  implement
         return UnsafeRefArrayAccess.lvElement(buffer, calcElementOffset(consumerIndex));
     }
 
-    private void soProducerIndex(long v) {
-        UNSAFE.putOrderedLong(this, P_INDEX_OFFSET, v);
+    private void soProducerIndex(long newIndex) {
+        UNSAFE.putOrderedLong(this, P_INDEX_OFFSET, newIndex);
     }
 
-    private void soConsumerIndex(long v) {
-        UNSAFE.putOrderedLong(this, C_INDEX_OFFSET, v);
+    private void soConsumerIndex(long newIndex) {
+        UNSAFE.putOrderedLong(this, C_INDEX_OFFSET, newIndex);
     }
 
     @Override

--- a/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscArrayQueue.java
@@ -34,12 +34,12 @@ abstract class SpscArrayQueueL1Pad<E> extends SpscArrayQueueColdField<E> {
     }
 }
 
-abstract class SpscArrayQueueProducerFields<E> extends SpscArrayQueueL1Pad<E> {
+abstract class SpscArrayQueueProducerIndexFields<E> extends SpscArrayQueueL1Pad<E> {
     protected final static long P_INDEX_OFFSET;
     static {
         try {
             P_INDEX_OFFSET =
-                UNSAFE.objectFieldOffset(SpscArrayQueueProducerFields.class.getDeclaredField("producerIndex"));
+                UNSAFE.objectFieldOffset(SpscArrayQueueProducerIndexFields.class.getDeclaredField("producerIndex"));
         } catch (NoSuchFieldException e) {
             throw new RuntimeException(e);
         }
@@ -47,7 +47,7 @@ abstract class SpscArrayQueueProducerFields<E> extends SpscArrayQueueL1Pad<E> {
     protected long producerIndex;
     protected long producerLimit;
 
-    public SpscArrayQueueProducerFields(int capacity) {
+    public SpscArrayQueueProducerIndexFields(int capacity) {
         super(capacity);
     }
     
@@ -62,7 +62,7 @@ abstract class SpscArrayQueueProducerFields<E> extends SpscArrayQueueL1Pad<E> {
     
 }
 
-abstract class SpscArrayQueueL2Pad<E> extends SpscArrayQueueProducerFields<E> {
+abstract class SpscArrayQueueL2Pad<E> extends SpscArrayQueueProducerIndexFields<E> {
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
 
@@ -71,18 +71,18 @@ abstract class SpscArrayQueueL2Pad<E> extends SpscArrayQueueProducerFields<E> {
     }
 }
 
-abstract class SpscArrayQueueConsumerField<E> extends SpscArrayQueueL2Pad<E> {
+abstract class SpscArrayQueueConsumerIndexField<E> extends SpscArrayQueueL2Pad<E> {
     protected long consumerIndex;
     protected final static long C_INDEX_OFFSET;
     static {
         try {
             C_INDEX_OFFSET =
-                UNSAFE.objectFieldOffset(SpscArrayQueueConsumerField.class.getDeclaredField("consumerIndex"));
+                UNSAFE.objectFieldOffset(SpscArrayQueueConsumerIndexField.class.getDeclaredField("consumerIndex"));
         } catch (NoSuchFieldException e) {
             throw new RuntimeException(e);
         }
     }
-    public SpscArrayQueueConsumerField(int capacity) {
+    public SpscArrayQueueConsumerIndexField(int capacity) {
         super(capacity);
     }
 
@@ -92,6 +92,15 @@ abstract class SpscArrayQueueConsumerField<E> extends SpscArrayQueueL2Pad<E> {
     
     protected final void soConsumerIndex(final long newIndex) {
         UNSAFE.putOrderedLong(this, C_INDEX_OFFSET, newIndex);
+    }
+}
+
+abstract class SpscArrayQueueL3Pad<E> extends SpscArrayQueueConsumerIndexField<E> {
+    long p01, p02, p03, p04, p05, p06, p07;
+    long p10, p11, p12, p13, p14, p15, p16, p17;
+
+    public SpscArrayQueueL3Pad(int capacity) {
+        super(capacity);
     }
 }
 
@@ -112,9 +121,7 @@ abstract class SpscArrayQueueConsumerField<E> extends SpscArrayQueueL2Pad<E> {
  *
  * @param <E>
  */
-public class SpscArrayQueue<E> extends SpscArrayQueueConsumerField<E> implements QueueProgressIndicators {
-    long p01, p02, p03, p04, p05, p06, p07;
-    long p10, p11, p12, p13, p14, p15, p16, p17;
+public class SpscArrayQueue<E> extends SpscArrayQueueL3Pad<E> implements QueueProgressIndicators {
     
     public SpscArrayQueue(final int capacity) {
         super(Math.max(capacity, 4));
@@ -189,7 +196,6 @@ public class SpscArrayQueue<E> extends SpscArrayQueueConsumerField<E> implements
     public E peek() {
         return lvElement(buffer, calcElementOffset(consumerIndex));
     }
-
 
 
     @Override

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicReferenceArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicReferenceArrayQueue.java
@@ -19,9 +19,10 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import org.jctools.queues.IndexedQueueSizeUtil;
 import org.jctools.queues.IndexedQueueSizeUtil.IndexedQueue;
+import org.jctools.queues.QueueProgressIndicators;
 import org.jctools.util.Pow2;
 
-abstract class AtomicReferenceArrayQueue<E> extends AbstractQueue<E> implements IndexedQueue {
+abstract class AtomicReferenceArrayQueue<E> extends AbstractQueue<E> implements IndexedQueue, QueueProgressIndicators {
     protected final AtomicReferenceArray<E> buffer;
     protected final int mask;
     public AtomicReferenceArrayQueue(int capacity) {
@@ -97,5 +98,15 @@ abstract class AtomicReferenceArrayQueue<E> extends AbstractQueue<E> implements 
     @Override
     public final boolean isEmpty() {
         return IndexedQueueSizeUtil.isEmpty(this);
+    }
+    
+    @Override
+    public final long currentProducerIndex() {
+        return lvProducerIndex();
+    }
+
+    @Override
+    public final long currentConsumerIndex() {
+        return lvConsumerIndex();
     }
 }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicReferenceArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicReferenceArrayQueue.java
@@ -77,4 +77,8 @@ abstract class AtomicReferenceArrayQueue<E> extends AbstractQueue<E> {
     protected final E lvElement(int offset) {
         return lvElement(buffer, offset);
     }
+
+    protected final int capacity() {
+        return (int) (mask + 1);
+    }
 }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicReferenceArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicReferenceArrayQueue.java
@@ -17,9 +17,11 @@ import java.util.AbstractQueue;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
+import org.jctools.queues.IndexedQueueSizeUtil;
+import org.jctools.queues.IndexedQueueSizeUtil.IndexedQueue;
 import org.jctools.util.Pow2;
 
-abstract class AtomicReferenceArrayQueue<E> extends AbstractQueue<E> {
+abstract class AtomicReferenceArrayQueue<E> extends AbstractQueue<E> implements IndexedQueue {
     protected final AtomicReferenceArray<E> buffer;
     protected final int mask;
     public AtomicReferenceArrayQueue(int capacity) {
@@ -80,5 +82,20 @@ abstract class AtomicReferenceArrayQueue<E> extends AbstractQueue<E> {
 
     protected final int capacity() {
         return (int) (mask + 1);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     *
+     */
+    @Override
+    public final int size() {
+        return IndexedQueueSizeUtil.size(this);
+    }
+
+    @Override
+    public final boolean isEmpty() {
+        return IndexedQueueSizeUtil.isEmpty(this);
     }
 }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpmcAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpmcAtomicArrayQueue.java
@@ -16,7 +16,6 @@ package org.jctools.queues.atomic;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
-import org.jctools.queues.QueueProgressIndicators;
 import org.jctools.util.RangeUtil;
 
 abstract class MpmcAtomicArrayQueueL1Pad<E> extends SequencedAtomicReferenceArrayQueue<E> {
@@ -81,8 +80,7 @@ abstract class MpmcAtomicArrayQueueL3Pad<E> extends MpmcAtomicArrayQueueConsumer
     }
 }
 
-public class MpmcAtomicArrayQueue<E> extends MpmcAtomicArrayQueueL3Pad<E>
-        implements QueueProgressIndicators {
+public class MpmcAtomicArrayQueue<E> extends MpmcAtomicArrayQueueL3Pad<E> {
     
     public MpmcAtomicArrayQueue(int capacity) {
         super(RangeUtil.checkGreaterThanOrEqual(capacity, 2, "capacity"));
@@ -174,16 +172,6 @@ public class MpmcAtomicArrayQueue<E> extends MpmcAtomicArrayQueueL3Pad<E>
             // only return null if queue is empty
         } while (e == null && cIndex != lvProducerIndex());
         return e;
-    }
-
-    @Override
-    public long currentProducerIndex() {
-        return lvProducerIndex();
-    }
-
-    @Override
-    public long currentConsumerIndex() {
-        return lvConsumerIndex();
     }
     
 

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpscAtomicArrayQueue.java
@@ -34,7 +34,7 @@ import org.jctools.queues.QueueProgressIndicators;
  * @param <E>
  */
 public final class MpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E>
-        implements IndexedQueue, QueueProgressIndicators {
+        implements QueueProgressIndicators {
     private static final AtomicLongFieldUpdater<MpscAtomicArrayQueue> C_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(MpscAtomicArrayQueue.class, "consumerIndex");
     private static final AtomicLongFieldUpdater<MpscAtomicArrayQueue> P_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(MpscAtomicArrayQueue.class, "producerIndex");
     private static final AtomicLongFieldUpdater<MpscAtomicArrayQueue> P_LIMIT_UPDATER = AtomicLongFieldUpdater.newUpdater(MpscAtomicArrayQueue.class, "producerLimit");

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpscAtomicArrayQueue.java
@@ -216,21 +216,6 @@ public final class MpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E>
         return e;
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     *
-     */
-    @Override
-    public int size() {
-        return IndexedQueueSizeUtil.size(this);
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return IndexedQueueSizeUtil.isEmpty(this);
-    }
-
     @Override
     public long currentProducerIndex() {
         return lvProducerIndex();
@@ -240,10 +225,12 @@ public final class MpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E>
     public long currentConsumerIndex() {
         return lvConsumerIndex();
     }
+    
     @Override
     public final long lvConsumerIndex() {
         return consumerIndex;
     }
+    
     @Override
     public final long lvProducerIndex() {
         return producerIndex;

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpscAtomicArrayQueue.java
@@ -17,7 +17,6 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import org.jctools.queues.MpscArrayQueue;
-import org.jctools.queues.QueueProgressIndicators;
 
 abstract class MpscAtomicArrayQueueL1Pad<E> extends AtomicReferenceArrayQueue<E> {
     long p00, p01, p02, p03, p04, p05, p06, p07;
@@ -130,7 +129,7 @@ abstract class MpscAtomicArrayQueueL3Pad<E> extends MpscAtomicArrayQueueConsumer
  *
  * @param <E>
  */
-public final class MpscAtomicArrayQueue<E> extends MpscAtomicArrayQueueL3Pad<E> implements QueueProgressIndicators {
+public final class MpscAtomicArrayQueue<E> extends MpscAtomicArrayQueueL3Pad<E> {
     
     public MpscAtomicArrayQueue(int capacity) {
         super(capacity);
@@ -351,15 +350,5 @@ public final class MpscAtomicArrayQueue<E> extends MpscAtomicArrayQueueL3Pad<E> 
             }
         }
         return e;
-    }
-
-    @Override
-    public long currentProducerIndex() {
-        return lvProducerIndex();
-    }
-
-    @Override
-    public long currentConsumerIndex() {
-        return lvConsumerIndex();
     }
 }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
@@ -117,6 +117,7 @@ public final class SpmcAtomicArrayQueue<E> extends SpmcAtomicArrayQueueL3Pad<E> 
     public SpmcAtomicArrayQueue(int capacity) {
         super(capacity);
     }
+    
     @Override
     public boolean offer(final E e) {
         if (null == e) {

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
@@ -17,9 +17,6 @@ package org.jctools.queues.atomic;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-import org.jctools.queues.IndexedQueueSizeUtil.IndexedQueue;
-import org.jctools.queues.QueueProgressIndicators;
-
 abstract class SpmcAtomicArrayQueueL1Pad<E> extends AtomicReferenceArrayQueue<E> {
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
@@ -114,7 +111,7 @@ abstract class SpmcAtomicArrayQueueL3Pad<E> extends SpmcAtomicArrayQueueProducer
  * @author akarnokd
  * @param <E>
  */
-public final class SpmcAtomicArrayQueue<E> extends SpmcAtomicArrayQueueL3Pad<E> implements QueueProgressIndicators {
+public final class SpmcAtomicArrayQueue<E> extends SpmcAtomicArrayQueueL3Pad<E> {
     
     public SpmcAtomicArrayQueue(int capacity) {
         super(capacity);
@@ -195,15 +192,5 @@ public final class SpmcAtomicArrayQueue<E> extends SpmcAtomicArrayQueueL3Pad<E> 
             }
         } while (null == (e = lvElement(buffer, calcElementOffset(currentConsumerIndex, mask))));
         return e;
-    }
-
-    @Override
-    public long currentProducerIndex() {
-        return lvProducerIndex();
-    }
-
-    @Override
-    public long currentConsumerIndex() {
-        return lvConsumerIndex();
     }
 }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
@@ -17,7 +17,6 @@ package org.jctools.queues.atomic;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-import org.jctools.queues.IndexedQueueSizeUtil;
 import org.jctools.queues.IndexedQueueSizeUtil.IndexedQueue;
 import org.jctools.queues.QueueProgressIndicators;
 
@@ -34,6 +33,7 @@ abstract class SpmcAtomicArrayQueueProducerField<E> extends SpmcAtomicArrayQueue
     private static final AtomicLongFieldUpdater<SpmcAtomicArrayQueueProducerField> P_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpmcAtomicArrayQueueProducerField.class, "producerIndex");
     private volatile long producerIndex;
 
+    @Override
     public final long lvProducerIndex() {
         return producerIndex;
     }
@@ -63,6 +63,7 @@ abstract class SpmcAtomicArrayQueueConsumerField<E> extends SpmcAtomicArrayQueue
         super(capacity);
     }
 
+    @Override
     public final long lvConsumerIndex() {
         return consumerIndex;
     }
@@ -193,16 +194,6 @@ public final class SpmcAtomicArrayQueue<E> extends SpmcAtomicArrayQueueL3Pad<E> 
             }
         } while (null == (e = lvElement(buffer, calcElementOffset(currentConsumerIndex, mask))));
         return e;
-    }
-    
-    @Override
-    public int size() {
-        return IndexedQueueSizeUtil.size(this);
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return IndexedQueueSizeUtil.isEmpty(this);
     }
 
     @Override

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
@@ -114,7 +114,7 @@ abstract class SpmcAtomicArrayQueueL3Pad<E> extends SpmcAtomicArrayQueueProducer
  * @author akarnokd
  * @param <E>
  */
-public final class SpmcAtomicArrayQueue<E> extends SpmcAtomicArrayQueueL3Pad<E> implements IndexedQueue, QueueProgressIndicators {
+public final class SpmcAtomicArrayQueue<E> extends SpmcAtomicArrayQueueL3Pad<E> implements QueueProgressIndicators {
     public SpmcAtomicArrayQueue(int capacity) {
         super(capacity);
     }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpmcAtomicArrayQueue.java
@@ -29,8 +29,8 @@ abstract class SpmcAtomicArrayQueueL1Pad<E> extends AtomicReferenceArrayQueue<E>
     }
 }
 
-abstract class SpmcAtomicArrayQueueProducerField<E> extends SpmcAtomicArrayQueueL1Pad<E> {
-    private static final AtomicLongFieldUpdater<SpmcAtomicArrayQueueProducerField> P_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpmcAtomicArrayQueueProducerField.class, "producerIndex");
+abstract class SpmcAtomicArrayQueueProducerIndexField<E> extends SpmcAtomicArrayQueueL1Pad<E> {
+    private static final AtomicLongFieldUpdater<SpmcAtomicArrayQueueProducerIndexField> P_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpmcAtomicArrayQueueProducerIndexField.class, "producerIndex");
     private volatile long producerIndex;
 
     @Override
@@ -42,11 +42,11 @@ abstract class SpmcAtomicArrayQueueProducerField<E> extends SpmcAtomicArrayQueue
         P_INDEX_UPDATER.lazySet(this, v);
     }
 
-    public SpmcAtomicArrayQueueProducerField(int capacity) {
+    public SpmcAtomicArrayQueueProducerIndexField(int capacity) {
         super(capacity);
     }
 }
-abstract class SpmcAtomicArrayQueueL2Pad<E> extends SpmcAtomicArrayQueueProducerField<E> {
+abstract class SpmcAtomicArrayQueueL2Pad<E> extends SpmcAtomicArrayQueueProducerIndexField<E> {
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
 
@@ -54,12 +54,12 @@ abstract class SpmcAtomicArrayQueueL2Pad<E> extends SpmcAtomicArrayQueueProducer
         super(capacity);
     }
 }
-abstract class SpmcAtomicArrayQueueConsumerField<E> extends SpmcAtomicArrayQueueL2Pad<E> {
-    protected static final AtomicLongFieldUpdater<SpmcAtomicArrayQueueConsumerField> C_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpmcAtomicArrayQueueConsumerField.class, "consumerIndex");
+abstract class SpmcAtomicArrayQueueConsumerIndexField<E> extends SpmcAtomicArrayQueueL2Pad<E> {
+    protected static final AtomicLongFieldUpdater<SpmcAtomicArrayQueueConsumerIndexField> C_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpmcAtomicArrayQueueConsumerIndexField.class, "consumerIndex");
 
     private volatile long consumerIndex;
 
-    public SpmcAtomicArrayQueueConsumerField(int capacity) {
+    public SpmcAtomicArrayQueueConsumerIndexField(int capacity) {
         super(capacity);
     }
 
@@ -73,7 +73,7 @@ abstract class SpmcAtomicArrayQueueConsumerField<E> extends SpmcAtomicArrayQueue
     }
 }
 
-abstract class SpmcAtomicArrayQueueMidPad<E> extends SpmcAtomicArrayQueueConsumerField<E> {
+abstract class SpmcAtomicArrayQueueMidPad<E> extends SpmcAtomicArrayQueueConsumerIndexField<E> {
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
 
@@ -115,6 +115,7 @@ abstract class SpmcAtomicArrayQueueL3Pad<E> extends SpmcAtomicArrayQueueProducer
  * @param <E>
  */
 public final class SpmcAtomicArrayQueue<E> extends SpmcAtomicArrayQueueL3Pad<E> implements QueueProgressIndicators {
+    
     public SpmcAtomicArrayQueue(int capacity) {
         super(capacity);
     }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
@@ -99,7 +99,7 @@ abstract class SpscAtomicArrayQueueConsumerField<E> extends SpscAtomicArrayQueue
  *
  * @param <E>
  */
-public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueConsumerField<E> implements IndexedQueue, QueueProgressIndicators {
+public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueConsumerField<E> implements QueueProgressIndicators {
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
     

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
@@ -38,8 +38,7 @@ abstract class SpscAtomicArrayQueueL1Pad<E> extends SpscAtomicArrayQueueColdFiel
 }
 
 abstract class SpscAtomicArrayQueueProducerFields<E> extends SpscAtomicArrayQueueL1Pad<E> {
-    protected static final AtomicLongFieldUpdater<SpscAtomicArrayQueueProducerFields> P_INDEX_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(SpscAtomicArrayQueueProducerFields.class, "producerIndex");
+    protected static final AtomicLongFieldUpdater<SpscAtomicArrayQueueProducerFields> P_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpscAtomicArrayQueueProducerFields.class, "producerIndex");
     protected volatile long producerIndex;
     protected long producerLimit;
 
@@ -58,8 +57,7 @@ abstract class SpscAtomicArrayQueueL2Pad<E> extends SpscAtomicArrayQueueProducer
 }
 
 abstract class SpscAtomicArrayQueueConsumerField<E> extends SpscAtomicArrayQueueL2Pad<E> {
-    protected static final AtomicLongFieldUpdater<SpscAtomicArrayQueueConsumerField> C_INDEX_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(SpscAtomicArrayQueueConsumerField.class, "consumerIndex");
+    protected static final AtomicLongFieldUpdater<SpscAtomicArrayQueueConsumerField> C_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpscAtomicArrayQueueConsumerField.class, "consumerIndex");
     protected volatile long consumerIndex;
     
     public SpscAtomicArrayQueueConsumerField(int capacity) {
@@ -87,7 +85,7 @@ public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueConsumerF
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
     
-    public SpscAtomicArrayQueue(int capacity) {
+    public SpscAtomicArrayQueue(final int capacity) {
         super(Math.max(capacity, 4));
     }
 
@@ -161,11 +159,11 @@ public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueConsumerF
         return lvElement(buffer, calcElementOffset(consumerIndex));
     }
 
-    private void soProducerIndex(long newIndex) {
+    private void soProducerIndex(final long newIndex) {
         P_INDEX_UPDATER.lazySet(this, newIndex);
     }
 
-    private void soConsumerIndex(long newIndex) {
+    private void soConsumerIndex(final long newIndex) {
         C_INDEX_UPDATER.lazySet(this, newIndex);
     }
 

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
@@ -16,8 +16,6 @@ package org.jctools.queues.atomic;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-import org.jctools.queues.QueueProgressIndicators;
-
 abstract class SpscAtomicArrayQueueColdField<E> extends AtomicReferenceArrayQueue<E> {
     public static final int MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
     protected final int lookAheadStep;
@@ -106,7 +104,7 @@ abstract class SpscAtomicArrayQueueL3Pad<E> extends SpscAtomicArrayQueueConsumer
  *
  * @param <E>
  */
-public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueL3Pad<E> implements QueueProgressIndicators {
+public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueL3Pad<E> {
 
     public SpscAtomicArrayQueue(final int capacity) {
         super(Math.max(capacity, 4));
@@ -180,15 +178,5 @@ public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueL3Pad<E> 
     @Override
     public E peek() {
         return lvElement(buffer, calcElementOffset(consumerIndex));
-    }
-    
-    @Override
-    public long currentProducerIndex() {
-        return lvProducerIndex();
-    }
-
-    @Override
-    public long currentConsumerIndex() {
-        return lvConsumerIndex();
     }
 }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
@@ -102,7 +102,7 @@ public final class SpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E> 
 
     @Override
     public E peek() {
-        return lvElement(calcElementOffset(consumerIndex.get()));
+        return lvElement(buffer, calcElementOffset(consumerIndex.get()));
     }
 
     @Override

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
@@ -126,6 +126,11 @@ public final class SpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E> 
     public int size() {
         return IndexedQueueSizeUtil.size(this);
     }
+
+    @Override
+    public boolean isEmpty() {
+        return IndexedQueueSizeUtil.isEmpty(this);
+    }
     
     @Override
     public long currentProducerIndex() {

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
@@ -16,8 +16,6 @@ package org.jctools.queues.atomic;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-import org.jctools.queues.IndexedQueueSizeUtil;
-import org.jctools.queues.IndexedQueueSizeUtil.IndexedQueue;
 import org.jctools.queues.QueueProgressIndicators;
 
 abstract class SpscAtomicArrayQueueColdField<E> extends AtomicReferenceArrayQueue<E> {
@@ -37,12 +35,12 @@ abstract class SpscAtomicArrayQueueL1Pad<E> extends SpscAtomicArrayQueueColdFiel
     }
 }
 
-abstract class SpscAtomicArrayQueueProducerFields<E> extends SpscAtomicArrayQueueL1Pad<E> {
-    protected static final AtomicLongFieldUpdater<SpscAtomicArrayQueueProducerFields> P_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpscAtomicArrayQueueProducerFields.class, "producerIndex");
+abstract class SpscAtomicArrayQueueProducerIndexFields<E> extends SpscAtomicArrayQueueL1Pad<E> {
+    protected static final AtomicLongFieldUpdater<SpscAtomicArrayQueueProducerIndexFields> P_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpscAtomicArrayQueueProducerIndexFields.class, "producerIndex");
     protected volatile long producerIndex;
     protected long producerLimit;
 
-    public SpscAtomicArrayQueueProducerFields(int capacity) {
+    public SpscAtomicArrayQueueProducerIndexFields(int capacity) {
         super(capacity);
     }
     
@@ -56,7 +54,7 @@ abstract class SpscAtomicArrayQueueProducerFields<E> extends SpscAtomicArrayQueu
     }
 }
 
-abstract class SpscAtomicArrayQueueL2Pad<E> extends SpscAtomicArrayQueueProducerFields<E> {
+abstract class SpscAtomicArrayQueueL2Pad<E> extends SpscAtomicArrayQueueProducerIndexFields<E> {
     long p01, p02, p03, p04, p05, p06, p07;
     long p10, p11, p12, p13, p14, p15, p16, p17;
 
@@ -65,11 +63,11 @@ abstract class SpscAtomicArrayQueueL2Pad<E> extends SpscAtomicArrayQueueProducer
     }
 }
 
-abstract class SpscAtomicArrayQueueConsumerField<E> extends SpscAtomicArrayQueueL2Pad<E> {
-    protected static final AtomicLongFieldUpdater<SpscAtomicArrayQueueConsumerField> C_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpscAtomicArrayQueueConsumerField.class, "consumerIndex");
+abstract class SpscAtomicArrayQueueConsumerIndexField<E> extends SpscAtomicArrayQueueL2Pad<E> {
+    protected static final AtomicLongFieldUpdater<SpscAtomicArrayQueueConsumerIndexField> C_INDEX_UPDATER = AtomicLongFieldUpdater.newUpdater(SpscAtomicArrayQueueConsumerIndexField.class, "consumerIndex");
     protected volatile long consumerIndex;
     
-    public SpscAtomicArrayQueueConsumerField(int capacity) {
+    public SpscAtomicArrayQueueConsumerIndexField(int capacity) {
         super(capacity);
     }
 
@@ -80,6 +78,15 @@ abstract class SpscAtomicArrayQueueConsumerField<E> extends SpscAtomicArrayQueue
 
     protected final void soConsumerIndex(final long newIndex) {
         C_INDEX_UPDATER.lazySet(this, newIndex);
+    }
+}
+
+abstract class SpscAtomicArrayQueueL3Pad<E> extends SpscAtomicArrayQueueConsumerIndexField<E> {
+    long p01, p02, p03, p04, p05, p06, p07;
+    long p10, p11, p12, p13, p14, p15, p16, p17;
+
+    public SpscAtomicArrayQueueL3Pad(int capacity) {
+        super(capacity);
     }
 }
 
@@ -99,10 +106,8 @@ abstract class SpscAtomicArrayQueueConsumerField<E> extends SpscAtomicArrayQueue
  *
  * @param <E>
  */
-public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueConsumerField<E> implements QueueProgressIndicators {
-    long p01, p02, p03, p04, p05, p06, p07;
-    long p10, p11, p12, p13, p14, p15, p16, p17;
-    
+public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueL3Pad<E> implements QueueProgressIndicators {
+
     public SpscAtomicArrayQueue(final int capacity) {
         super(Math.max(capacity, 4));
     }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
@@ -43,10 +43,10 @@ public final class SpscAtomicArrayQueue<E> extends AtomicReferenceArrayQueue<E> 
     final AtomicLong consumerIndex;
     final int lookAheadStep;
     public SpscAtomicArrayQueue(int capacity) {
-        super(capacity);
+        super(Math.max(capacity, 4));
         this.producerIndex = new AtomicLong();
         this.consumerIndex = new AtomicLong();
-        lookAheadStep = Math.min(capacity / 4, MAX_LOOK_AHEAD_STEP);
+        lookAheadStep = Math.min(capacity() / 4, MAX_LOOK_AHEAD_STEP);
     }
 
     @Override

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
@@ -45,6 +45,14 @@ abstract class SpscAtomicArrayQueueProducerFields<E> extends SpscAtomicArrayQueu
     public SpscAtomicArrayQueueProducerFields(int capacity) {
         super(capacity);
     }
+    
+    public final long lvProducerIndex() {
+        return producerIndex;
+    }
+
+    protected final void soProducerIndex(final long newIndex) {
+        P_INDEX_UPDATER.lazySet(this, newIndex);
+    }
 }
 
 abstract class SpscAtomicArrayQueueL2Pad<E> extends SpscAtomicArrayQueueProducerFields<E> {
@@ -62,6 +70,14 @@ abstract class SpscAtomicArrayQueueConsumerField<E> extends SpscAtomicArrayQueue
     
     public SpscAtomicArrayQueueConsumerField(int capacity) {
         super(capacity);
+    }
+
+    public final long lvConsumerIndex() {
+        return consumerIndex;
+    }
+
+    protected final void soConsumerIndex(final long newIndex) {
+        C_INDEX_UPDATER.lazySet(this, newIndex);
     }
 }
 
@@ -157,24 +173,6 @@ public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueConsumerF
     @Override
     public E peek() {
         return lvElement(buffer, calcElementOffset(consumerIndex));
-    }
-
-    private void soProducerIndex(final long newIndex) {
-        P_INDEX_UPDATER.lazySet(this, newIndex);
-    }
-
-    private void soConsumerIndex(final long newIndex) {
-        C_INDEX_UPDATER.lazySet(this, newIndex);
-    }
-
-    @Override
-    public long lvProducerIndex() {
-        return producerIndex;
-    }
-
-    @Override
-    public long lvConsumerIndex() {
-        return consumerIndex;
     }
 
     @Override

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscAtomicArrayQueue.java
@@ -46,6 +46,7 @@ abstract class SpscAtomicArrayQueueProducerFields<E> extends SpscAtomicArrayQueu
         super(capacity);
     }
     
+    @Override
     public final long lvProducerIndex() {
         return producerIndex;
     }
@@ -72,6 +73,7 @@ abstract class SpscAtomicArrayQueueConsumerField<E> extends SpscAtomicArrayQueue
         super(capacity);
     }
 
+    @Override
     public final long lvConsumerIndex() {
         return consumerIndex;
     }
@@ -173,16 +175,6 @@ public final class SpscAtomicArrayQueue<E> extends SpscAtomicArrayQueueConsumerF
     @Override
     public E peek() {
         return lvElement(buffer, calcElementOffset(consumerIndex));
-    }
-
-    @Override
-    public int size() {
-        return IndexedQueueSizeUtil.size(this);
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return IndexedQueueSizeUtil.isEmpty(this);
     }
     
     @Override

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/SpscAtomicArrayQueueTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/SpscAtomicArrayQueueTest.java
@@ -28,8 +28,8 @@ public class SpscAtomicArrayQueueTest
         // Arrange
         final SpscAtomicArrayQueue<Object> q = new SpscAtomicArrayQueue<Object>(1024);
         // starting point for empty queue at max long, next offer will wrap the producerIndex
-        q.consumerIndex.set(Long.MAX_VALUE);
-        q.producerIndex.set(Long.MAX_VALUE);
+        q.consumerIndex = Long.MAX_VALUE;
+        q.producerIndex = Long.MAX_VALUE;
         q.producerLimit = Long.MAX_VALUE;
         // valid starting point
         assertThat(q, emptyAndZeroSize());

--- a/jctools-core/src/test/java/org/jctools/queues/atomic/SpscAtomicArrayQueueTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/atomic/SpscAtomicArrayQueueTest.java
@@ -30,7 +30,7 @@ public class SpscAtomicArrayQueueTest
         // starting point for empty queue at max long, next offer will wrap the producerIndex
         q.consumerIndex.set(Long.MAX_VALUE);
         q.producerIndex.set(Long.MAX_VALUE);
-        q.producerLookAhead = Long.MAX_VALUE;
+        q.producerLimit = Long.MAX_VALUE;
         // valid starting point
         assertThat(q, emptyAndZeroSize());
 


### PR DESCRIPTION
This change is in an effort to ensure the *AtomicArrayQueue classes (aka atomic queues) are as similar to the vanilla *ArrayQueue classes (aka unsafe queues) as possible. In doing so, methods that have been given some love in the unsafe class but not the atomic class has been treated with a little bit of attention and affection.

I've replaced all use of AtomicLong's with AtomicFieldUpdaters to avoid dereferences and with that I've added padding. Performance impact of this is unverified. 

In the atomic classes I've reduced duplication with regards to size(), isEmpty(), currentProducerIndex() and currentConsumerIndex() by moving them into the parent class, AtomicReferenceArrayQueue.

I've kept the commit history as-is as this change was implemented in several stages it  might be easier to understand each stage separately, but I'm very happy to rewrite the history as required.