### PR TITLE
Split JvmInfo into unsafe and portable components.

### DIFF
--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/channels/ChannelThroughputBackoffNone.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/throughput/channels/ChannelThroughputBackoffNone.java
@@ -22,7 +22,7 @@ import org.jctools.channels.ChannelProducer;
 import org.jctools.channels.ChannelReceiver;
 import org.jctools.channels.mpsc.MpscChannel;
 import org.jctools.channels.spsc.SpscChannel;
-import org.jctools.util.JvmInfo;
+import org.jctools.util.PortableJvmInfo;
 import org.jctools.util.Pow2;
 import org.openjdk.jmh.annotations.AuxCounters;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -77,7 +77,7 @@ public class ChannelThroughputBackoffNone {
             }
         };
         buffer = ByteBuffer
-                .allocateDirect(Pow2.roundToPowerOfTwo(capacity * 2) * (8 + 4) + JvmInfo.CACHE_LINE_SIZE * 5);
+                .allocateDirect(Pow2.roundToPowerOfTwo(capacity * 2) * (8 + 4) + PortableJvmInfo.CACHE_LINE_SIZE * 5);
 
         switch (type) {
         case Spsc:

--- a/jctools-core/src/main/java/org/jctools/queues/ConcurrentSequencedCircularArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/ConcurrentSequencedCircularArrayQueue.java
@@ -13,7 +13,7 @@
  */
 package org.jctools.queues;
 
-import org.jctools.util.JvmInfo;
+import org.jctools.util.PortableJvmInfo;
 import org.jctools.util.UnsafeAccess;
 
 import static org.jctools.util.UnsafeAccess.UNSAFE;
@@ -30,7 +30,7 @@ public abstract class ConcurrentSequencedCircularArrayQueue<E> extends Concurren
             throw new IllegalStateException("Unexpected long[] element size");
         }
         // 2 cache lines pad
-        SEQ_BUFFER_PAD = (JvmInfo.CACHE_LINE_SIZE * 2) / scale;
+        SEQ_BUFFER_PAD = (PortableJvmInfo.CACHE_LINE_SIZE * 2) / scale;
         // Including the buffer pad in the array base offset
         ARRAY_BASE = UnsafeAccess.UNSAFE.arrayBaseOffset(long[].class) + (SEQ_BUFFER_PAD * scale);
     }

--- a/jctools-core/src/main/java/org/jctools/queues/MpmcArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpmcArrayQueue.java
@@ -13,7 +13,7 @@
  */
 package org.jctools.queues;
 
-import static org.jctools.util.JvmInfo.CPUs;
+import static org.jctools.util.PortableJvmInfo.CPUs;
 import static org.jctools.util.UnsafeAccess.UNSAFE;
 import static org.jctools.util.UnsafeRefArrayAccess.lpElement;
 import static org.jctools.util.UnsafeRefArrayAccess.soElement;

--- a/jctools-core/src/main/java/org/jctools/queues/MpscCompoundQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpscCompoundQueue.java
@@ -13,7 +13,7 @@
  */
 package org.jctools.queues;
 
-import static org.jctools.util.JvmInfo.CPUs;
+import static org.jctools.util.PortableJvmInfo.CPUs;
 import static org.jctools.util.Pow2.isPowerOfTwo;
 import static org.jctools.util.Pow2.roundToPowerOfTwo;
 

--- a/jctools-core/src/main/java/org/jctools/queues/PaddedCircularArrayOffsetCalculator.java
+++ b/jctools-core/src/main/java/org/jctools/queues/PaddedCircularArrayOffsetCalculator.java
@@ -1,7 +1,7 @@
 package org.jctools.queues;
 
 import org.jctools.util.InternalAPI;
-import org.jctools.util.JvmInfo;
+import org.jctools.util.PortableJvmInfo;
 import org.jctools.util.UnsafeRefArrayAccess;
 
 @InternalAPI
@@ -13,7 +13,7 @@ public final class PaddedCircularArrayOffsetCalculator
     static
     {
         // 2 cache lines pad
-        REF_BUFFER_PAD = (JvmInfo.CACHE_LINE_SIZE * 2) >> UnsafeRefArrayAccess.REF_ELEMENT_SHIFT;
+        REF_BUFFER_PAD = (PortableJvmInfo.CACHE_LINE_SIZE * 2) >> UnsafeRefArrayAccess.REF_ELEMENT_SHIFT;
         // Including the buffer pad in the array base offset
         final int paddingOffset = REF_BUFFER_PAD << UnsafeRefArrayAccess.REF_ELEMENT_SHIFT;
         REF_ARRAY_BASE = UnsafeRefArrayAccess.REF_ARRAY_BASE + paddingOffset;

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/BaseMpscLinkedAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/BaseMpscLinkedAtomicArrayQueue.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-import static org.jctools.util.JvmInfo.CPUs;
+import static org.jctools.util.PortableJvmInfo.CPUs;
 
 abstract class BaseMpscLinkedAtomicArrayQueuePad1<E> extends AbstractQueue<E> {
     long p01, p02, p03, p04, p05, p06, p07;

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpmcAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpmcAtomicArrayQueue.java
@@ -13,7 +13,7 @@
  */
 package org.jctools.queues.atomic;
 
-import static org.jctools.util.JvmInfo.CPUs;
+import static org.jctools.util.PortableJvmInfo.CPUs;
 import org.jctools.util.RangeUtil;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceArray;

--- a/jctools-core/src/main/java/org/jctools/util/PortableJvmInfo.java
+++ b/jctools-core/src/main/java/org/jctools/util/PortableJvmInfo.java
@@ -1,8 +1,10 @@
 package org.jctools.util;
 
+/**
+ * JVM Information that is standard and available on all JVMs (i.e. does not use unsafe)
+ */
 @InternalAPI
-public interface JvmInfo {
+public interface PortableJvmInfo {
     int CACHE_LINE_SIZE = Integer.getInteger("jctools.cacheLineSize", 64);
-    int PAGE_SIZE = UnsafeAccess.UNSAFE.pageSize();
     int CPUs = Runtime.getRuntime().availableProcessors();
 }

--- a/jctools-core/src/main/java/org/jctools/util/UnsafeJvmInfo.java
+++ b/jctools-core/src/main/java/org/jctools/util/UnsafeJvmInfo.java
@@ -1,0 +1,6 @@
+package org.jctools.util;
+
+@InternalAPI
+public interface UnsafeJvmInfo {
+    int PAGE_SIZE = UnsafeAccess.UNSAFE.pageSize();
+}

--- a/jctools-core/src/test/java/org/jctools/queues/QueueSanityTestMpscCompound.java
+++ b/jctools-core/src/test/java/org/jctools/queues/QueueSanityTestMpscCompound.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.jctools.util.JvmInfo.CPUs;
+import static org.jctools.util.PortableJvmInfo.CPUs;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)

--- a/jctools-experimental/src/main/java/org/jctools/channels/OffHeapFixedMessageSizeRingBuffer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/OffHeapFixedMessageSizeRingBuffer.java
@@ -13,7 +13,7 @@
  */
 package org.jctools.channels;
 
-import static org.jctools.util.JvmInfo.CACHE_LINE_SIZE;
+import static org.jctools.util.PortableJvmInfo.CACHE_LINE_SIZE;
 import static org.jctools.util.UnsafeAccess.UNSAFE;
 import static org.jctools.util.UnsafeDirectByteBuffer.alignedSlice;
 import static org.jctools.util.UnsafeDirectByteBuffer.allocateAlignedByteBuffer;
@@ -21,7 +21,6 @@ import static org.jctools.util.UnsafeDirectByteBuffer.allocateAlignedByteBuffer;
 import java.nio.ByteBuffer;
 
 import org.jctools.channels.proxy.ProxyChannelRingBuffer;
-import org.jctools.util.JvmInfo;
 import org.jctools.util.Pow2;
 import org.jctools.util.UnsafeDirectByteBuffer;
 import org.jctools.util.UnsafeRefArrayAccess;
@@ -39,7 +38,7 @@ public abstract class OffHeapFixedMessageSizeRingBuffer extends ProxyChannelRing
     public static final int WRITE_RELEASE_INDICATOR = 2;
     public static final int WRITE_ACQUIRE_INDICATOR = 3;
     public static final byte MESSAGE_INDICATOR_SIZE = 4;
-    public static final int HEADER_SIZE = 4 * JvmInfo.CACHE_LINE_SIZE;
+    public static final int HEADER_SIZE = 4 * CACHE_LINE_SIZE;
 
     private final ByteBuffer buffy;
     protected final long bufferAddress;
@@ -105,7 +104,7 @@ public abstract class OffHeapFixedMessageSizeRingBuffer extends ProxyChannelRing
         this.buffy = alignedSlice(HEADER_SIZE + (actualCapacity * (this.messageSize)), CACHE_LINE_SIZE, buff);
 
         long alignedAddress = UnsafeDirectByteBuffer.getAddress(buffy);
-        if (alignedAddress % JvmInfo.CACHE_LINE_SIZE != 0) {
+        if (alignedAddress % CACHE_LINE_SIZE != 0) {
             throw new IllegalStateException("buffer is expected to be cache line aligned by now");
         }
         // Layout of the RingBuffer (assuming 64b cache line):
@@ -115,7 +114,7 @@ public abstract class OffHeapFixedMessageSizeRingBuffer extends ProxyChannelRing
         // pad(64b) |
         // buffer (capacity * messageSize)
         this.consumerIndexAddress = alignedAddress;
-        this.producerIndexAddress = this.consumerIndexAddress + 2 * JvmInfo.CACHE_LINE_SIZE;
+        this.producerIndexAddress = this.consumerIndexAddress + 2 * CACHE_LINE_SIZE;
         this.bufferAddress = alignedAddress + HEADER_SIZE;
         this.mask = actualCapacity - 1;
         

--- a/jctools-experimental/src/main/java/org/jctools/channels/mpsc/MpscFFLamportOffHeapFixedSizeRingBuffer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/mpsc/MpscFFLamportOffHeapFixedSizeRingBuffer.java
@@ -17,7 +17,7 @@ import java.nio.ByteBuffer;
 
 import org.jctools.channels.OffHeapFixedMessageSizeRingBuffer;
 
-import org.jctools.util.JvmInfo;
+import org.jctools.util.PortableJvmInfo;
 import org.jctools.util.Pow2;
 
 import static org.jctools.util.UnsafeAccess.UNSAFE;
@@ -35,7 +35,7 @@ import static org.jctools.util.UnsafeDirectByteBuffer.allocateAlignedByteBuffer;
 public final class MpscFFLamportOffHeapFixedSizeRingBuffer extends OffHeapFixedMessageSizeRingBuffer {
 
    public MpscFFLamportOffHeapFixedSizeRingBuffer(final int capacity, final int primitiveMessageSize, final int referenceMessageSize) {
-      this(allocateAlignedByteBuffer(getRequiredBufferSize(capacity, primitiveMessageSize), JvmInfo.CACHE_LINE_SIZE), Pow2.roundToPowerOfTwo(capacity), true, true, true, primitiveMessageSize, createReferenceArray(capacity, referenceMessageSize), referenceMessageSize);
+      this(allocateAlignedByteBuffer(getRequiredBufferSize(capacity, primitiveMessageSize), PortableJvmInfo.CACHE_LINE_SIZE), Pow2.roundToPowerOfTwo(capacity), true, true, true, primitiveMessageSize, createReferenceArray(capacity, referenceMessageSize), referenceMessageSize);
    }
 
    private final long consumerIndexCacheAddress;

--- a/jctools-experimental/src/main/java/org/jctools/channels/mpsc/MpscOffHeapFixedSizeRingBuffer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/mpsc/MpscOffHeapFixedSizeRingBuffer.java
@@ -19,7 +19,7 @@ import static org.jctools.util.UnsafeDirectByteBuffer.allocateAlignedByteBuffer;
 import java.nio.ByteBuffer;
 
 import org.jctools.channels.OffHeapFixedMessageSizeRingBuffer;
-import org.jctools.util.JvmInfo;
+import org.jctools.util.PortableJvmInfo;
 import org.jctools.util.Pow2;
 
 /**
@@ -31,7 +31,7 @@ import org.jctools.util.Pow2;
 public class MpscOffHeapFixedSizeRingBuffer extends OffHeapFixedMessageSizeRingBuffer {
 
     public MpscOffHeapFixedSizeRingBuffer(final int capacity, final int messageSize, int referenceMessageSize) {
-        this(allocateAlignedByteBuffer(getRequiredBufferSize(capacity, messageSize), JvmInfo.CACHE_LINE_SIZE),
+        this(allocateAlignedByteBuffer(getRequiredBufferSize(capacity, messageSize), PortableJvmInfo.CACHE_LINE_SIZE),
                 Pow2.roundToPowerOfTwo(capacity),
                 true,
                 true,

--- a/jctools-experimental/src/main/java/org/jctools/channels/spsc/SpscOffHeapFixedSizeRingBuffer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/spsc/SpscOffHeapFixedSizeRingBuffer.java
@@ -13,7 +13,7 @@
  */
 package org.jctools.channels.spsc;
 
-import static org.jctools.util.JvmInfo.CACHE_LINE_SIZE;
+import static org.jctools.util.PortableJvmInfo.CACHE_LINE_SIZE;
 import static org.jctools.util.UnsafeAccess.UNSAFE;
 import static org.jctools.util.UnsafeDirectByteBuffer.allocateAlignedByteBuffer;
 

--- a/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounter.java
+++ b/jctools-experimental/src/main/java/org/jctools/counters/FixedSizeStripedLongCounter.java
@@ -4,7 +4,7 @@ import static org.jctools.util.UnsafeAccess.UNSAFE;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.jctools.util.JvmInfo;
+import org.jctools.util.PortableJvmInfo;
 import org.jctools.util.Pow2;
 
 /**
@@ -18,11 +18,11 @@ abstract class FixedSizeStripedLongCounterPrePad {
     long l9, l10, l11, l12, l13, l14, l15;
 }
 abstract class FixedSizeStripedLongCounterFields extends FixedSizeStripedLongCounterPrePad {
-    protected static final int CACHE_LINE_IN_LONGS = JvmInfo.CACHE_LINE_SIZE / 8;
+    protected static final int CACHE_LINE_IN_LONGS = PortableJvmInfo.CACHE_LINE_SIZE / 8;
     // place first element at the end of the cache line of the array object
-    protected static final long COUNTER_ARRAY_BASE = Math.max(UNSAFE.arrayBaseOffset(long[].class), JvmInfo.CACHE_LINE_SIZE - 8);
+    protected static final long COUNTER_ARRAY_BASE = Math.max(UNSAFE.arrayBaseOffset(long[].class), PortableJvmInfo.CACHE_LINE_SIZE - 8);
     // element shift is enlarged to include the padding, still aligned to long
-    protected static final long ELEMENT_SHIFT = Integer.numberOfTrailingZeros(JvmInfo.CACHE_LINE_SIZE);
+    protected static final long ELEMENT_SHIFT = Integer.numberOfTrailingZeros(PortableJvmInfo.CACHE_LINE_SIZE);
     
     // we pad each element in the array to effectively write a counter in each cache line
     protected final long[] cells;

--- a/jctools-experimental/src/main/java/org/jctools/queues/SpscOffHeapIntQueue.java
+++ b/jctools-experimental/src/main/java/org/jctools/queues/SpscOffHeapIntQueue.java
@@ -13,7 +13,7 @@
  */
 package org.jctools.queues;
 
-import org.jctools.util.JvmInfo;
+import org.jctools.util.PortableJvmInfo;
 import org.jctools.util.Pow2;
 import org.jctools.util.UnsafeAccess;
 import org.jctools.util.UnsafeDirectByteBuffer;
@@ -42,12 +42,12 @@ public final class SpscOffHeapIntQueue extends AbstractQueue<Integer> {
 	public SpscOffHeapIntQueue(final int capacity) {
 		this(allocateAlignedByteBuffer(
 		        getRequiredBufferSize(capacity),
-		        JvmInfo.CACHE_LINE_SIZE),
+		        PortableJvmInfo.CACHE_LINE_SIZE),
 		        Pow2.roundToPowerOfTwo(capacity),(byte)(PRODUCER | CONSUMER));
 	}
 
 	public static int getRequiredBufferSize(final int capacity) {
-	    return 4 * JvmInfo.CACHE_LINE_SIZE + (Pow2.roundToPowerOfTwo(capacity) << INT_ELEMENT_SCALE);
+	    return 4 * PortableJvmInfo.CACHE_LINE_SIZE + (Pow2.roundToPowerOfTwo(capacity) << INT_ELEMENT_SCALE);
     }
 
 	/**
@@ -61,16 +61,16 @@ public final class SpscOffHeapIntQueue extends AbstractQueue<Integer> {
 	public SpscOffHeapIntQueue(final ByteBuffer buff,
 			final int capacity, byte viewMask) {
 		this.capacity = Pow2.roundToPowerOfTwo(capacity);
-		buffy = alignedSlice(4 * JvmInfo.CACHE_LINE_SIZE + (this.capacity << INT_ELEMENT_SCALE),
-									JvmInfo.CACHE_LINE_SIZE, buff);
+		buffy = alignedSlice(4 * PortableJvmInfo.CACHE_LINE_SIZE + (this.capacity << INT_ELEMENT_SCALE),
+		        PortableJvmInfo.CACHE_LINE_SIZE, buff);
 
 		long alignedAddress = UnsafeDirectByteBuffer.getAddress(buffy);
 
 		headAddress = alignedAddress;
 		tailCacheAddress = headAddress + 8;
-		tailAddress = headAddress + 2 * JvmInfo.CACHE_LINE_SIZE;
+		tailAddress = headAddress + 2 * PortableJvmInfo.CACHE_LINE_SIZE;
 		headCacheAddress = tailAddress + 8;
-		arrayBase = alignedAddress + 4 * JvmInfo.CACHE_LINE_SIZE;
+		arrayBase = alignedAddress + 4 * PortableJvmInfo.CACHE_LINE_SIZE;
 		// producer owns tail and headCache
 		if((viewMask & PRODUCER) == PRODUCER){
     		setHeadCache(0);

--- a/jctools-experimental/src/main/java/org/jctools/util/UnsafeDirectByteBuffer.java
+++ b/jctools-experimental/src/main/java/org/jctools/util/UnsafeDirectByteBuffer.java
@@ -73,14 +73,14 @@ public class UnsafeDirectByteBuffer {
 	}
 
 	public static boolean isPageAligned(long address) {
-		return (address & (JvmInfo.PAGE_SIZE - 1)) == 0;
+		return (address & (UnsafeJvmInfo.PAGE_SIZE - 1)) == 0;
 	}
 
 	/**
 	 * This assumes cache line is 64b
 	 */
 	public static boolean isCacheAligned(long address) {
-		return (address & (JvmInfo.CACHE_LINE_SIZE - 1)) == 0;
+		return (address & (PortableJvmInfo.CACHE_LINE_SIZE - 1)) == 0;
 	}
 
 	public static boolean isAligned(long address, long align) {

--- a/jctools-experimental/src/test/java/org/jctools/counters/FixedSizeStripedLongCounterTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/counters/FixedSizeStripedLongCounterTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.jctools.util.JvmInfo;
+import org.jctools.util.PortableJvmInfo;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -21,7 +21,7 @@ public class FixedSizeStripedLongCounterTest {
 
     @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
-        int stripesCount = JvmInfo.CPUs * 2;
+        int stripesCount = PortableJvmInfo.CPUs * 2;
         ArrayList<Object[]> list = new ArrayList<>();
         list.add(new Counter[]{new FixedSizeStripedLongCounterV6(stripesCount)});
         list.add(new Counter[]{new FixedSizeStripedLongCounterV8(stripesCount)});
@@ -46,7 +46,7 @@ public class FixedSizeStripedLongCounterTest {
 
     @Test
     public void testMultipleThreadsCounterSanity() throws Exception {
-        int threadsCount = JvmInfo.CPUs;
+        int threadsCount = PortableJvmInfo.CPUs;
         AtomicLong summary = new AtomicLong();
         AtomicBoolean running = new AtomicBoolean(true);
         CountDownLatch startLatch = new CountDownLatch(1);


### PR DESCRIPTION
Many classes access how many CPUs on a system which sadly also results in a call to unsafe during clinit which is not suitable for Android users.

See https://github.com/netty/netty/issues/7117#issuecomment-322972545 for example

Essentially all that's been done here is to split it into unsafe and portable variants. Manually tracing through the class hierarchy indicates to me this should be sufficient to ensure the 'atomic' queues are portable and resolve this issue.