### PR TITLE
producerReferenceArrayIndex incorrect for multi producer use cases

### DIFF
--- a/jctools-experimental/src/main/java/org/jctools/channels/proxy/ProxyChannelRingBuffer.java
+++ b/jctools-experimental/src/main/java/org/jctools/channels/proxy/ProxyChannelRingBuffer.java
@@ -42,16 +42,18 @@ public abstract class ProxyChannelRingBuffer {
     /**
      * Get the position index of the consumer in the reference array
      * 
+     * @param offset the current offset of the consumer returned from {@link #readAcquire()}
      * @return the consumer index
      */
-    protected abstract long consumerReferenceArrayIndex();
+    protected abstract long consumerReferenceArrayIndex(long offset);
 
     /**
      * Get the position index of the producer in the reference array
      * 
+     * @param offset the current offset of the producer returned from {@link #writeAcquire()}
      * @return the producer index
      */
-    protected abstract long producerReferenceArrayIndex();
+    protected abstract long producerReferenceArrayIndex(long offset);
 
     /**
      * Write a reference into the index of the reference array.

--- a/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoProxyResult.java
+++ b/jctools-experimental/src/test/java/org/jctools/channels/proxy/DemoProxyResult.java
@@ -60,7 +60,7 @@ public class DemoProxyResult extends SpscOffHeapFixedSizeRingBuffer implements P
                     break;
                 }
                 case 4: {
-                    long referenceArrayIndex = this.consumerReferenceArrayIndex();
+                    long referenceArrayIndex = this.consumerReferenceArrayIndex(rOffset);
                     Object x = this.readReference(referenceArrayIndex);
                     Object y = this.readReference(referenceArrayIndex + 1);
                     this.readRelease(rOffset);
@@ -68,7 +68,7 @@ public class DemoProxyResult extends SpscOffHeapFixedSizeRingBuffer implements P
                     break;
                 }
                 case 5: {
-                    long referenceArrayIndex = this.consumerReferenceArrayIndex();
+                    long referenceArrayIndex = this.consumerReferenceArrayIndex(rOffset);
                     Object x = this.readReference(referenceArrayIndex);
                     int y = UnsafeAccess.UNSAFE.getInt(rOffset + 4);
                     Object z = this.readReference(referenceArrayIndex + 1);
@@ -77,7 +77,7 @@ public class DemoProxyResult extends SpscOffHeapFixedSizeRingBuffer implements P
                     break;
                 }
                 case 6: {
-                    long referenceArrayIndex = this.consumerReferenceArrayIndex();
+                    long referenceArrayIndex = this.consumerReferenceArrayIndex(rOffset);
                     int x = UnsafeAccess.UNSAFE.getInt(rOffset + 4);
                     Object y = this.readReference(referenceArrayIndex);
                     Object z = this.readReference(referenceArrayIndex + 1);
@@ -118,7 +118,7 @@ public class DemoProxyResult extends SpscOffHeapFixedSizeRingBuffer implements P
     @Override
     public void call4(Object x, CustomType y) {
         long wOffset = ProxyChannelFactory.writeAcquireWithWaitStrategy(this, waitStrategy);
-        long arrayReferenceBaseIndex = this.producerReferenceArrayIndex();
+        long arrayReferenceBaseIndex = this.producerReferenceArrayIndex(wOffset);
         this.writeReference(arrayReferenceBaseIndex, x);
         this.writeReference(arrayReferenceBaseIndex + 1, y);
         this.writeRelease(wOffset, 4);
@@ -127,7 +127,7 @@ public class DemoProxyResult extends SpscOffHeapFixedSizeRingBuffer implements P
     @Override
     public void call5(CustomType x, int y, CustomType z) {
         long wOffset = ProxyChannelFactory.writeAcquireWithWaitStrategy(this, waitStrategy);
-        long arrayReferenceBaseIndex = this.producerReferenceArrayIndex();
+        long arrayReferenceBaseIndex = this.producerReferenceArrayIndex(wOffset);
         this.writeReference(arrayReferenceBaseIndex, x);
         UnsafeAccess.UNSAFE.putInt(wOffset + 4, y);
         this.writeReference(arrayReferenceBaseIndex + 1, z);
@@ -137,7 +137,7 @@ public class DemoProxyResult extends SpscOffHeapFixedSizeRingBuffer implements P
     @Override
     public void call6(int x, CustomType[] y, CustomType... z) {
         long wOffset = ProxyChannelFactory.writeAcquireWithWaitStrategy(this, waitStrategy);
-        long arrayReferenceBaseIndex = this.producerReferenceArrayIndex();
+        long arrayReferenceBaseIndex = this.producerReferenceArrayIndex(wOffset);
         UnsafeAccess.UNSAFE.putInt(wOffset + 4, x);
         this.writeReference(arrayReferenceBaseIndex, y);
         this.writeReference(arrayReferenceBaseIndex + 1, z);


### PR DESCRIPTION
Fixed bug whereby with MP proxy (or in the future, MC) you could
read a reference before it was written. This is due to writeAcquire()
advancing the producerIndex (or readAcquire() advancing the
consumerIndex in the MC) case.

When the producerReferenceArrayIndex() (or consumerReferenceArrayIndex())
method is called it reads the current producerIndex. Clearly sometimes
in the MP case this index will have changed between writeAcquire() and
producerReferenceArrayIndex() calls. Thus P0 who won the writeAcquire for
slot X, could end up skipping over the corresponding ref array slot if P1
completed writeAcquire() before P0 finished it's write to the ref array.
In such a case also P0 and P1 compete for P1's ref array slot, last write wins.

The result is nulls in some slots and incorrect values in others.