### PR TITLE
MpscLinkedAtomicQueue API breakage

### DIFF
--- a/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicLinkedQueueGenerator.java
+++ b/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicLinkedQueueGenerator.java
@@ -50,6 +50,7 @@ import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 public final class JavaParsingAtomicLinkedQueueGenerator extends VoidVisitorAdapter<Void> {
     private static final String GEN_DIRECTIVE_CLASS_CONTAINS_ORDERED_FIELD_ACCESSORS = "$gen:ordered-fields";
     private static final String GEN_DIRECTIVE_METHOD_IGNORE = "$gen:ignore";
+    private static final String MPSC_LINKED_ATOMIC_QUEUE_NAME = "MpscLinkedAtomicQueue";
     private static final String INDENT_LEVEL = "    ";
     private final String sourceFileName;
 
@@ -83,7 +84,7 @@ public final class JavaParsingAtomicLinkedQueueGenerator extends VoidVisitorAdap
         replaceParentClassesForAtomics(node);
 
         node.setName(translateQueueName(node.getNameAsString()));
-        if ("MpscLinkedAtomicQueue".equals(node.getNameAsString())) {
+        if (MPSC_LINKED_ATOMIC_QUEUE_NAME.equals(node.getNameAsString())) {
             /*
              * Special case for MPSC
              */
@@ -115,6 +116,11 @@ public final class JavaParsingAtomicLinkedQueueGenerator extends VoidVisitorAdap
         super.visit(n, arg);
         // Update the ctor to match the class name
         n.setName(translateQueueName(n.getNameAsString()));
+        if (MPSC_LINKED_ATOMIC_QUEUE_NAME.equals(n.getNameAsString())) {
+            // Special case for MPSC because the Unsafe variant has a static factory method and a protected constructor.
+            n.setModifier(Modifier.PROTECTED, false);
+            n.setModifier(Modifier.PUBLIC, true);
+        }
     }
 
     @Override

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpscAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpscAtomicArrayQueue.java
@@ -232,7 +232,7 @@ public class MpscAtomicArrayQueue<E> extends MpscAtomicArrayQueueL3Pad<E> {
      * Lock free offer using a single CAS. As class name suggests access is permitted to many threads
      * concurrently.
      *
-     * @see java.util.Queue#offer   
+     * @see java.util.Queue#offer
      * @see org.jctools.queues.MessagePassingQueue#offer
      */
     @Override

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/MpscLinkedAtomicQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/MpscLinkedAtomicQueue.java
@@ -44,7 +44,7 @@ import org.jctools.queues.MpmcArrayQueue;
  */
 public final class MpscLinkedAtomicQueue<E> extends BaseLinkedAtomicQueue<E> {
 
-    protected MpscLinkedAtomicQueue() {
+    public MpscLinkedAtomicQueue() {
         LinkedQueueAtomicNode<E> node = newNode();
         spConsumerNode(node);
         xchgProducerNode(node);


### PR DESCRIPTION
Motivation:
4e68fd268b6d936c6e73aacb1badaa48586d539f introduced a new code generation utility. However this commit removed the public constructor for MpscLinkedAtomicQueue because MpscLinkedQueue has a static factory method and a protected constructor.

Modifications:
- Restore the public constructor in MpscLinkedAtomicQueue

Result:
Original API restored for MpscLinkedAtomicQueue.