### PR TITLE
ConcurrentMap contract requires to give a result based on equals, not on reference equality

### DIFF
--- a/jctools-core/src/main/java/org/jctools/maps/NonBlockingHashMap.java
+++ b/jctools-core/src/main/java/org/jctools/maps/NonBlockingHashMap.java
@@ -340,7 +340,9 @@ public class NonBlockingHashMap<TypeK, TypeV>
   /** Atomically do a {@link #remove(Object)} if-and-only-if the key is mapped
    *  to a value which is <code>equals</code> to the given value.
    *  @throws NullPointerException if the specified key or value is null */
-  public boolean remove     ( Object key,Object val ) { return putIfMatch( key,TOMBSTONE, val ) == val; }
+  public boolean remove     ( Object key,Object val ) {
+    return Objects.equals(putIfMatch( key,TOMBSTONE, val ), val);
+  }
 
   /** Atomically do a <code>put(key,val)</code> if-and-only-if the key is
    *  mapped to some value already.
@@ -353,7 +355,7 @@ public class NonBlockingHashMap<TypeK, TypeV>
    *  @throws NullPointerException if the specified key or value is null */
   @Override
   public boolean replace    ( TypeK  key, TypeV  oldValue, TypeV newValue ) {
-    return putIfMatch( key, newValue, oldValue ) == oldValue;
+    return Objects.equals(putIfMatch( key, newValue, oldValue ), oldValue);
   }
 
 

--- a/jctools-core/src/test/java/org/jctools/maps/nbhm_test/NBHM_Tester2.java
+++ b/jctools-core/src/test/java/org/jctools/maps/nbhm_test/NBHM_Tester2.java
@@ -483,6 +483,26 @@ public class NBHM_Tester2
         assertEquals("values().iterator() count", itemCount, iteratorCount);
     }
 
+    // --- Tests on equality of values
+    @Test
+    public void replaceResultIsBasedOnEquality() {
+        NonBlockingHashMap<Integer, Integer> map = new NonBlockingHashMap<>();
+        Integer initialValue = new Integer(10);
+        map.put(1, initialValue);
+        assertTrue(map.replace(1,  initialValue, 20));
+        assertTrue(map.replace(1,  new Integer(20), 30));
+    }
+
+    @Test
+    public void removeResultIsBasedOnEquality() {
+        NonBlockingHashMap<Integer, Integer> map = new NonBlockingHashMap<>();
+        Integer initialValue = new Integer(10);
+        map.put(1, initialValue);
+        assertTrue(map.remove(1,  initialValue));
+        map.put(1, initialValue);
+        assertTrue(map.remove(1,  new Integer(10)));
+    }
+
     // Throw a ClassCastException if I see a tombstone during key-compares
     private static class KeyBonk
     {


### PR DESCRIPTION
According to the Javadoc, true should be returned in case of equality for both `remove` and `replace`.

```
if (map.containsKey(key) && Objects.equals(map.get(key), oldValue)) {
  map.put(key, newValue);
  return true;
} else
  return false;
```

 The replacement and removal are correctly done using `equals`, however the return value is currently based on reference equality. This patch solves this issue using `Objects.equals`.