### PR TITLE
Fixes #216: Size of SpscGrowableArrayQueue can exceeds max capacity

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/SpscGrowableArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/SpscGrowableArrayQueue.java
@@ -114,7 +114,7 @@ public class SpscGrowableArrayQueue<E> extends BaseSpscLinkedArrayQueue<E>
                     long currConsumerIndex = lvConsumerIndex();
                     // use lookAheadStep to store the consumer distance from final buffer
                     this.lookAheadStep = -(index - currConsumerIndex);
-                    producerBufferLimit = currConsumerIndex + maxCapacity - 1;
+                    producerBufferLimit = currConsumerIndex + maxCapacity;
                 }
                 else
                 {

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/SpscGrowableAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/SpscGrowableAtomicArrayQueue.java
@@ -106,7 +106,7 @@ public class SpscGrowableAtomicArrayQueue<E> extends BaseSpscLinkedAtomicArrayQu
                     long currConsumerIndex = lvConsumerIndex();
                     // use lookAheadStep to store the consumer distance from final buffer
                     this.lookAheadStep = -(index - currConsumerIndex);
-                    producerBufferLimit = currConsumerIndex + maxCapacity - 1;
+                    producerBufferLimit = currConsumerIndex + maxCapacity;
                 } else {
                     producerBufferLimit = index + producerMask - 1;
                     adjustLookAheadStep(newCapacity);

--- a/jctools-core/src/test/java/org/jctools/queues/QueueSanityTestSpscGrowable.java
+++ b/jctools-core/src/test/java/org/jctools/queues/QueueSanityTestSpscGrowable.java
@@ -2,12 +2,16 @@ package org.jctools.queues;
 
 import org.jctools.queues.spec.ConcurrentQueueSpec;
 import org.jctools.queues.spec.Ordering;
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Queue;
+
+import static org.hamcrest.Matchers.is;
 
 @RunWith(Parameterized.class)
 public class QueueSanityTestSpscGrowable extends QueueSanityTest
@@ -25,6 +29,32 @@ public class QueueSanityTestSpscGrowable extends QueueSanityTest
         list.add(makeQueue(1, 1, 16, Ordering.FIFO, new SpscGrowableArrayQueue<>(8, 16)));
         list.add(makeQueue(1, 1, SIZE, Ordering.FIFO, new SpscGrowableArrayQueue<>(8, SIZE)));
         return list;
+    }
+
+    @Test
+    public void testSizeNeverExceedCapacity()
+    {
+        final SpscGrowableArrayQueue<Integer> q = new SpscGrowableArrayQueue<>(8, 16);
+        final Integer v = 0;
+        final int capacity = q.capacity();
+        for (int i = 0; i < capacity; i++)
+        {
+            Assert.assertTrue(q.offer(v));
+        }
+        Assert.assertFalse(q.offer(v));
+        Assert.assertThat(q.size(), is(capacity));
+        for (int i = 0; i < 6; i++)
+        {
+            Assert.assertEquals(v, q.poll());
+        }
+        //the consumer is left in the chunk previous the last and biggest one
+        Assert.assertThat(q.size(), is(capacity - 6));
+        for (int i = 0; i < 6; i++)
+        {
+            q.offer(v);
+        }
+        Assert.assertThat(q.size(), is(capacity));
+        Assert.assertFalse(q.offer(v));
     }
 
 }


### PR DESCRIPTION
Adjust producer limit in order to allow one more element to be added
in place of the unneeded JUMP when the max capacity producer buffer
has been allocated