### PR TITLE
Update maven-bundle-plugin to 4.1.0

### DIFF
--- a/jctools-core/pom.xml
+++ b/jctools-core/pom.xml
@@ -49,7 +49,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.5.4</version>
+				<version>4.1.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>


### PR DESCRIPTION
Motivation is the version we use, 2.5.4, has a bug that runs the build a
second time.

I manually inspected the bundle output by eye and could see no real
differences. A little bit of line-wrapping and swapping the order of
attributes was the difference.

Fixes #189