### PR TITLE
Don't mark generated linked atomic queues as final

### DIFF
--- a/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicArrayQueueGenerator.java
+++ b/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicArrayQueueGenerator.java
@@ -551,14 +551,16 @@ public final class JavaParsingAtomicArrayQueueGenerator extends VoidVisitorAdapt
             }
             outputFileName += ".java";
 
+            File outputFile = new File(outputDirectory, outputFileName);
             try {
-                writer = new FileWriter(new File(outputDirectory, outputFileName));
+                writer = new FileWriter(outputFile);
                 writer.write(cu.toString());
             } finally {
                 if (writer != null) {
                     writer.close();
                 }
             }
+            System.out.println("Saved to " + outputFile);
         }
     }
 

--- a/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicLinkedQueueGenerator.java
+++ b/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicLinkedQueueGenerator.java
@@ -89,7 +89,6 @@ public final class JavaParsingAtomicLinkedQueueGenerator extends VoidVisitorAdap
              * Special case for MPSC
              */
             node.removeModifier(Modifier.ABSTRACT);
-            node.addModifier(Modifier.FINAL);
         }
 
         if (isCommentPresent(node, GEN_DIRECTIVE_CLASS_CONTAINS_ORDERED_FIELD_ACCESSORS)) {


### PR DESCRIPTION
Reported in #208, fixed but subsequent regressed as fix edited generated
source. This change should fix it permanently.