### PR TITLE
Fix replace missing value

### DIFF
--- a/jctools-core/src/main/java/org/jctools/maps/NonBlockingHashMap.java
+++ b/jctools-core/src/main/java/org/jctools/maps/NonBlockingHashMap.java
@@ -379,7 +379,6 @@ public class NonBlockingHashMap<TypeK, TypeV>
     if (oldVal == null || newVal == null) throw new NullPointerException();
     final Object res = putIfMatch( this, _kvs, key, newVal, oldVal );
     assert !(res instanceof Prime);
-    assert res != null;
     return res == TOMBSTONE ? null : (TypeV)res;
   }
 

--- a/jctools-core/src/main/java/org/jctools/maps/NonBlockingHashMap.java
+++ b/jctools-core/src/main/java/org/jctools/maps/NonBlockingHashMap.java
@@ -379,6 +379,7 @@ public class NonBlockingHashMap<TypeK, TypeV>
     if (oldVal == null || newVal == null) throw new NullPointerException();
     final Object res = putIfMatch( this, _kvs, key, newVal, oldVal );
     assert !(res instanceof Prime);
+    assert res != null;
     return res == TOMBSTONE ? null : (TypeV)res;
   }
 

--- a/jctools-core/src/test/java/org/jctools/maps/nbhm_test/NBHM_Tester2.java
+++ b/jctools-core/src/test/java/org/jctools/maps/nbhm_test/NBHM_Tester2.java
@@ -484,6 +484,13 @@ public class NBHM_Tester2
         assertEquals("values().iterator() count", itemCount, iteratorCount);
     }
 
+    @Test
+    public void replaceMissingValue() {
+        NonBlockingHashMap<Integer, Integer> map = new NonBlockingHashMap<>();
+        assertNull(map.replace(1, 2));
+        assertFalse(map.replace(1, 2, 3));
+    }
+
     // --- Tests on equality of values
     @Test
     public void replaceResultIsBasedOnEquality() {


### PR DESCRIPTION
Fix to the issue https://github.com/JCTools/JCTools/issues/244 to avoid throwing AssertionError when value is missing by key on replace