### PR TITLE
MpscBlockingConsumerArrayQueue interruption fixes

### DIFF
--- a/jctools-core/src/test/java/org/jctools/queues/QueueSanityTestMpscBlockingConsumerArrayExtended.java
+++ b/jctools-core/src/test/java/org/jctools/queues/QueueSanityTestMpscBlockingConsumerArrayExtended.java
@@ -115,6 +115,7 @@ public class QueueSanityTestMpscBlockingConsumerArrayExtended
     public void testTakeBlocksAndIsInterrupted() throws Exception
     {
         final AtomicBoolean wasInterrupted = new AtomicBoolean();
+        final AtomicBoolean interruptedStatusAfter = new AtomicBoolean();
         final MpscBlockingConsumerArrayQueue<Integer> q = new MpscBlockingConsumerArrayQueue<>(1024);
         Thread consumer = new Thread(() -> {
             try
@@ -125,6 +126,7 @@ public class QueueSanityTestMpscBlockingConsumerArrayExtended
             {
                 wasInterrupted.set(true);
             }
+            interruptedStatusAfter.set(Thread.currentThread().isInterrupted());
         });
         consumer.setDaemon(true);
         consumer.start();
@@ -136,8 +138,12 @@ public class QueueSanityTestMpscBlockingConsumerArrayExtended
         consumer.interrupt();
         consumer.join();
         assertTrue(wasInterrupted.get());
+        assertFalse(interruptedStatusAfter.get());
+        
+        // Queue should remain in original state (empty)
+        assertNull(q.poll());
     }
-    
+
     @Test(timeout = 1000L)
     public void testTakeSomeElementsThenBlocksAndIsInterrupted() throws Exception
     {


### PR DESCRIPTION
After consumer is interrupted in `take()` method:
- Ensure queue reverts to original non-blocked state (revert producer index and blocking field) - otherwise for example a subsequent `poll()` will spin indefinitely
- Clear interrupt flag (consistent with equivalent j.u.c. behaviour)

Extended unit tests to cover this