### PR TITLE
Mpmc Xadd q doesn't need load chunk index after chunk search on offer

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddArrayQueue.java
@@ -400,15 +400,11 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcProgressiveChunkedQueueP
         final int chunkShift = this.chunkShift;
         final long producerSeq = getAndIncrementProducerIndex();
         final int pOffset = (int) (producerSeq & chunkMask);
-        long chunkIndex = producerSeq >> chunkShift;
+        final long chunkIndex = producerSeq >> chunkShift;
         AtomicChunk<E> producerBuffer = lvProducerBuffer();
         if (producerBuffer.lvIndex() != chunkIndex)
         {
             producerBuffer = producerBufferOf(producerBuffer, chunkIndex);
-            if (producerBuffer.isPooled())
-            {
-                chunkIndex = producerBuffer.lvIndex();
-            }
         }
         final boolean isPooled = producerBuffer.isPooled();
         if (isPooled)


### PR DESCRIPTION
While reading the last fix for this q I've found what it seems an unnecessary volatile load, probably put there in the past (by me!) for validation purposes, but unnecessary for the q mechanics.