### PR TITLE
xadd qs producer buffer rotation improvements

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddArrayQueue.java
@@ -332,7 +332,7 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcProgressiveChunkedQueueP
             //try validate against the last producer chunk index
             if (lvProducerChunkIndex() == producerChunkIndex)
             {
-                producerBuffer = appendNextChunk(producerBuffer, producerChunkIndex, chunkMask + 1);
+                producerBuffer = appendNextChunks(producerBuffer, producerChunkIndex, chunkMask + 1, -jumpBackward);
             }
             else
             {
@@ -349,31 +349,37 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcProgressiveChunkedQueueP
         return producerBuffer;
     }
 
-    private AtomicChunk<E> appendNextChunk(AtomicChunk<E> producerBuffer, long chunkIndex, int chunkSize)
+    private AtomicChunk<E> appendNextChunks(AtomicChunk<E> producerBuffer, long chunkIndex, int chunkSize, long chunks)
     {
         assert chunkIndex != AtomicChunk.NIL_CHUNK_INDEX;
-        final long nextChunkIndex = chunkIndex + 1;
         //prevent other concurrent attempts on appendNextChunk
         if (!casProducerChunkIndex(chunkIndex, ROTATION))
         {
             return null;
         }
-        AtomicChunk<E> newChunk = freeBuffer.poll();
-        if (newChunk != null)
+        AtomicChunk<E> newChunk = null;
+        for (long i = 1; i <= chunks; i++)
         {
-            assert newChunk.lvIndex() == AtomicChunk.NIL_CHUNK_INDEX;
-            newChunk.spPrev(producerBuffer);
-            //index set is releasing prev, allowing other pending offers to continue
-            newChunk.soIndex(nextChunkIndex);
+            final long nextChunkIndex = chunkIndex + i;
+            newChunk = freeBuffer.poll();
+            if (newChunk != null)
+            {
+                //single-writer: producerBuffer::index == nextChunkIndex is protecting it
+                assert newChunk.lvIndex() == AtomicChunk.NIL_CHUNK_INDEX;
+                newChunk.spPrev(producerBuffer);
+                //index set is releasing prev, allowing other pending offers to continue
+                newChunk.soIndex(nextChunkIndex);
+            }
+            else
+            {
+                newChunk = new AtomicChunk<E>(nextChunkIndex, producerBuffer, chunkSize, false);
+            }
+            soProducerBuffer(newChunk);
+            //link the next chunk only when finished
+            producerBuffer.soNext(newChunk);
+            producerBuffer = newChunk;
         }
-        else
-        {
-            newChunk = new AtomicChunk<E>(nextChunkIndex, producerBuffer, chunkSize, false);
-        }
-        soProducerBuffer(newChunk);
-        soProducerChunkIndex(nextChunkIndex);
-        //link the next chunk only when finished
-        producerBuffer.soNext(newChunk);
+        soProducerChunkIndex(chunkIndex + chunks);
         return newChunk;
     }
 

--- a/jctools-core/src/main/java/org/jctools/queues/MpscUnboundedXaddArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpscUnboundedXaddArrayQueue.java
@@ -280,7 +280,7 @@ public class MpscUnboundedXaddArrayQueue<E> extends MpscProgressiveChunkedQueueP
             //try validate against the last producer chunk index
             if (lvProducerChunkIndex() == producerChunkIndex)
             {
-                producerBuffer = appendNextChunk(producerBuffer, producerChunkIndex, chunkMask + 1);
+                producerBuffer = appendNextChunks(producerBuffer, producerChunkIndex, chunkMask + 1, -jumpBackward);
             }
             else
             {
@@ -297,7 +297,7 @@ public class MpscUnboundedXaddArrayQueue<E> extends MpscProgressiveChunkedQueueP
         return producerBuffer;
     }
 
-    private AtomicChunk<E> appendNextChunk(AtomicChunk<E> producerBuffer, long chunkIndex, int chunkSize)
+    private AtomicChunk<E> appendNextChunks(AtomicChunk<E> producerBuffer, long chunkIndex, int chunkSize, long chunks)
     {
         assert chunkIndex != AtomicChunk.NIL_CHUNK_INDEX;
         //prevent other concurrent attempts on appendNextChunk
@@ -305,24 +305,29 @@ public class MpscUnboundedXaddArrayQueue<E> extends MpscProgressiveChunkedQueueP
         {
             return null;
         }
-        final long nextChunkIndex = chunkIndex + 1;
-        AtomicChunk<E> newChunk = freeBuffer.poll();
-        if (newChunk != null)
+        AtomicChunk<E> newChunk = null;
+        for (long i = 1; i <= chunks; i++)
         {
-            //single-writer: producerBuffer::index == nextChunkIndex is protecting it
-            assert newChunk.lvIndex() == AtomicChunk.NIL_CHUNK_INDEX;
-            newChunk.spPrev(producerBuffer);
-            //index set is releasing prev, allowing other pending offers to continue
-            newChunk.soIndex(nextChunkIndex);
+            final long nextChunkIndex = chunkIndex + i;
+            newChunk = freeBuffer.poll();
+            if (newChunk != null)
+            {
+                //single-writer: producerBuffer::index == nextChunkIndex is protecting it
+                assert newChunk.lvIndex() == AtomicChunk.NIL_CHUNK_INDEX;
+                newChunk.spPrev(producerBuffer);
+                //index set is releasing prev, allowing other pending offers to continue
+                newChunk.soIndex(nextChunkIndex);
+            }
+            else
+            {
+                newChunk = new AtomicChunk<E>(nextChunkIndex, producerBuffer, chunkSize, false);
+            }
+            soProducerBuffer(newChunk);
+            //link the next chunk only when finished
+            producerBuffer.soNext(newChunk);
+            producerBuffer = newChunk;
         }
-        else
-        {
-            newChunk = new AtomicChunk<E>(nextChunkIndex, producerBuffer, chunkSize, false);
-        }
-        soProducerBuffer(newChunk);
-        soProducerChunkIndex(nextChunkIndex);
-        //link the next chunk only when finished
-        producerBuffer.soNext(newChunk);
+        soProducerChunkIndex(chunkIndex + chunks);
         return newChunk;
     }
 


### PR DESCRIPTION
It contains 2 improvements on producer buffer rotation:

1. `producerBuffer` is always fully initialized: it allows racing producers to reach their target chunks, if needed  
2. save `casProducerChunkIndex` attempts by appending batch of chunks, if needed