### PR TITLE
Save producerIndex load while polling a pooled chunk on mpmc xadd q

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddArrayQueue.java
@@ -366,7 +366,7 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcProgressiveChunkedQueueP
             if (newChunk != null)
             {
                 //single-writer: producerBuffer::index == nextChunkIndex is protecting it
-                assert newChunk.lvIndex() == AtomicChunk.NIL_CHUNK_INDEX;
+                assert newChunk.lvIndex() < producerBuffer.lvIndex();
                 newChunk.spPrev(producerBuffer);
                 //index set is releasing prev, allowing other pending offers to continue
                 newChunk.soIndex(nextChunkIndex);
@@ -446,9 +446,6 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcProgressiveChunkedQueueP
         {
             next = consumerBuffer.lvNext();
         }
-        //prevent other consumers to use it, but need to await next != null
-        //or the producer won't be able to append next on a NIL_CHUNK_INDEX!
-        consumerBuffer.soIndex(AtomicChunk.NIL_CHUNK_INDEX);
         //we can freely spin awaiting producer, because we are the only one in charge to
         //rotate the consumer buffer and use next
         final E e = spinForElement(next, consumerOffset);
@@ -523,24 +520,19 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcProgressiveChunkedQueueP
             else
             {
                 final boolean pooled = consumerBuffer.isPooled();
-                e = pooled ? null : consumerBuffer.lvElement(consumerOffset);
-                final long index = pooled ? consumerBuffer.lvSequence(consumerOffset) : consumerBuffer.lvIndex();
-                if (index != chunkIndex)
-                {
-                    if (index < chunkIndex)
-                    {
-                        // if pooled:
-                        // a) consumerBuffer::index > chunkIndex: a chunk used in the past or at its first use
-                        // b) consumerBuffer::index < chunkIndex: a rotation is in progress
-                        // c) consumerBuffer::index == chunkIndex: rotation is happened, not yet an element in
-                        // For a) there is no need to check q emptiness, but doing it isn't wrong,
-                        // because the check will fail (ie q isn't empty re consumerIndex):
-                        // consumerBuffer::index > chunkIndex means that others have proceeded consuming new elements.
-                        // For b) and c) the emptiness check is necessary, because if there are no other elements
-                        // poll *must* return null.
-                        //
-                        // if !pooled:
-                        // - the rotation isn't happened yet
+                if (pooled) {
+                    final long sequence = consumerBuffer.lvSequence(consumerOffset);
+                    if (sequence != chunkIndex) {
+                        if (sequence > chunkIndex) {
+                            //stale view of the world
+                            continue;
+                        }
+                        final long index = consumerBuffer.lvIndex();
+                        if (index > chunkIndex)
+                        {
+                            //stale view of the world
+                            continue;
+                        }
                         if (consumerIndex >= pIndex && // test against cached pIndex
                             consumerIndex == (pIndex = lvProducerIndex()))
                         { // update pIndex if we must
@@ -549,23 +541,24 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcProgressiveChunkedQueueP
                         }
                         continue;
                     }
-                    else
+                } else {
+                    e = consumerBuffer.lvElement(consumerOffset);
+                    final long index = consumerBuffer.lvIndex();
+                    if (index != chunkIndex || e == null)
                     {
-                        //Stale view of the world: retry!
+                        if (index > chunkIndex)
+                        {
+                            //stale view of the world
+                            continue;
+                        }
+                        if (consumerIndex >= pIndex && // test against cached pIndex
+                            consumerIndex == (pIndex = lvProducerIndex()))
+                        { // update pIndex if we must
+                            // strict empty check, this ensures [Queue.poll() == null iff isEmpty()]
+                            return null;
+                        }
                         continue;
                     }
-                }
-                assert index == chunkIndex;
-                if (!pooled && e == null)
-                {
-                    if (consumerIndex >= pIndex && // test against cached pIndex
-                        consumerIndex == (pIndex = lvProducerIndex()))
-                    { // update pIndex if we must
-                        // strict empty check, this ensures [Queue.poll() == null iff isEmpty()]
-                        return null;
-                    }
-                    //we are awaiting the producer here
-                    continue;
                 }
             }
             if (casConsumerIndex(consumerIndex, consumerIndex + 1))
@@ -633,7 +626,6 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcProgressiveChunkedQueueP
             if (consumerBuffer.lvIndex() != chunkIndex)
             {
                 e = null;
-                continue;
             }
         }
         while (e == null && consumerIndex != lvProducerIndex());


### PR DESCRIPTION
The change on poll introduced by fc2978401df8462ce5457c265c8a92b1151a2a62 has caused a performance regression due to an increased number of `producerIndex` loads.
This PR is using `consumerBuffer::index` to save some `producerIndex` loads, while preserving correctness of fast fail (ie return null) during a rotation if there are no other elements but the first one in the next chunk.

Some results by running
```
$ java -jar microbenchmarks.jar org.jctools.jmh.throughput.QueueThroughputBackoffNone -f 10 -p qType=MpmcUnboundedXaddArrayQueue,MpmcArrayQueue -p qCapacity=131072 -tg 5,5
```
master:
```
Benchmark                                    (qCapacity)                      (qType)   Mode  Cnt   Score   Error   Units
QueueThroughputBackoffNone.tpt                    131072  MpmcUnboundedXaddArrayQueue  thrpt  100  18.042 ± 0.290  ops/us
QueueThroughputBackoffNone.tpt:offer              131072  MpmcUnboundedXaddArrayQueue  thrpt  100  14.393 ± 0.279  ops/us
QueueThroughputBackoffNone.tpt:offersFailed       131072  MpmcUnboundedXaddArrayQueue  thrpt  100     ≈ 0          ops/us
QueueThroughputBackoffNone.tpt:offersMade         131072  MpmcUnboundedXaddArrayQueue  thrpt  100  14.410 ± 0.280  ops/us
QueueThroughputBackoffNone.tpt:poll               131072  MpmcUnboundedXaddArrayQueue  thrpt  100   3.649 ± 0.048  ops/us
QueueThroughputBackoffNone.tpt:pollsFailed        131072  MpmcUnboundedXaddArrayQueue  thrpt  100   0.001 ± 0.001  ops/us
QueueThroughputBackoffNone.tpt:pollsMade          131072  MpmcUnboundedXaddArrayQueue  thrpt  100   3.654 ± 0.048  ops/us
QueueThroughputBackoffNone.tpt                    131072               MpmcArrayQueue  thrpt  100   8.911 ± 0.270  ops/us
QueueThroughputBackoffNone.tpt:offer              131072               MpmcArrayQueue  thrpt  100   4.460 ± 0.141  ops/us
QueueThroughputBackoffNone.tpt:offersFailed       131072               MpmcArrayQueue  thrpt  100   0.029 ± 0.031  ops/us
QueueThroughputBackoffNone.tpt:offersMade         131072               MpmcArrayQueue  thrpt  100   4.435 ± 0.145  ops/us
QueueThroughputBackoffNone.tpt:poll               131072               MpmcArrayQueue  thrpt  100   4.451 ± 0.134  ops/us
QueueThroughputBackoffNone.tpt:pollsFailed        131072               MpmcArrayQueue  thrpt  100   0.045 ± 0.020  ops/us
QueueThroughputBackoffNone.tpt:pollsMade          131072               MpmcArrayQueue  thrpt  100   4.410 ± 0.144  ops/us
```
this PR:
```
Benchmark                                    (qCapacity)                      (qType)   Mode  Cnt   Score   Error   Units
QueueThroughputBackoffNone.tpt                    131072  MpmcUnboundedXaddArrayQueue  thrpt  100  24.164 ± 0.660  ops/us
QueueThroughputBackoffNone.tpt:offer              131072  MpmcUnboundedXaddArrayQueue  thrpt  100  19.203 ± 0.559  ops/us
QueueThroughputBackoffNone.tpt:offersFailed       131072  MpmcUnboundedXaddArrayQueue  thrpt  100     ≈ 0          ops/us
QueueThroughputBackoffNone.tpt:offersMade         131072  MpmcUnboundedXaddArrayQueue  thrpt  100  19.223 ± 0.559  ops/us
QueueThroughputBackoffNone.tpt:poll               131072  MpmcUnboundedXaddArrayQueue  thrpt  100   4.961 ± 0.124  ops/us
QueueThroughputBackoffNone.tpt:pollsFailed        131072  MpmcUnboundedXaddArrayQueue  thrpt  100   0.001 ± 0.001  ops/us
QueueThroughputBackoffNone.tpt:pollsMade          131072  MpmcUnboundedXaddArrayQueue  thrpt  100   4.968 ± 0.124  ops/us
QueueThroughputBackoffNone.tpt                    131072               MpmcArrayQueue  thrpt  100   9.535 ± 0.251  ops/us
QueueThroughputBackoffNone.tpt:offer              131072               MpmcArrayQueue  thrpt  100   4.764 ± 0.130  ops/us
QueueThroughputBackoffNone.tpt:offersFailed       131072               MpmcArrayQueue  thrpt  100   0.001 ± 0.002  ops/us
QueueThroughputBackoffNone.tpt:offersMade         131072               MpmcArrayQueue  thrpt  100   4.766 ± 0.131  ops/us
QueueThroughputBackoffNone.tpt:poll               131072               MpmcArrayQueue  thrpt  100   4.771 ± 0.121  ops/us
QueueThroughputBackoffNone.tpt:pollsFailed        131072               MpmcArrayQueue  thrpt  100   0.018 ± 0.008  ops/us
QueueThroughputBackoffNone.tpt:pollsMade          131072               MpmcArrayQueue  thrpt  100   4.756 ± 0.128  ops/us
```
These results show that saving unecessary `producerIndex` loads on rotation can make a lot of difference, hence https://github.com/JCTools/JCTools/issues/265 could be very beneficial to be implemented for a future release.