### PR TITLE
mpsc xadd q relaxedPeek cannot assume element presence

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/MpscUnboundedXaddArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpscUnboundedXaddArrayQueue.java
@@ -547,7 +547,7 @@ public class MpscUnboundedXaddArrayQueue<E> extends MpscUnboundedXaddArrayQueueP
                 return null;
             }
             this.consumerBuffer = consumerBuffer;
-            //the element on consumerIndex can't be null from now on
+            //the element can't be null from now on
             e = spinForElement(consumerBuffer, 0);
         }
         else
@@ -580,15 +580,8 @@ public class MpscUnboundedXaddArrayQueue<E> extends MpscUnboundedXaddArrayQueueP
                 return null;
             }
             consumerBuffer = next;
-            //the element on consumerIndex can't be null from now on
         }
-        final E e = consumerBuffer.lvElement(consumerOffset);
-        if (e != null)
-        {
-            return e;
-        }
-        assert !firstElementOfNewChunk;
-        return null;
+        return consumerBuffer.lvElement(consumerOffset);
     }
 
     @Override


### PR DESCRIPTION
Relaxed peek cannot assume immediate element presence on `next` due to `consumerBuffer::next` presence, because there are cases where the element is set after `next` (eg when the appending thread is the same that will set its first element)