### PR TITLE
wait-free relaxedPoll for mpmc xadd q

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddArrayQueue.java
@@ -459,7 +459,7 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcUnboundedXaddArrayQueueP
         next.soElement(consumerOffset, null);
         next.spPrev(null);
         //save from nepotism
-        consumerBuffer.spNext(null);
+        consumerBuffer.soNext(null);
         if (consumerBuffer.isPooled())
         {
             final boolean offered = freeBuffer.offer(consumerBuffer);
@@ -493,18 +493,21 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcUnboundedXaddArrayQueueP
             firstElementOfNewChunk = consumerOffset == 0 && consumerIndex >= chunkSize;
             if (firstElementOfNewChunk)
             {
-                next = consumerBuffer.lvNext();
-                final long expectedChunkIndex = chunkIndex - 1;
                 //we don't care about < or >, because if:
                 //- consumerBuffer::index < expectedChunkIndex: another consumer has rotated consumerBuffer,
                 //  but not reused (yet, if possible)
                 //- consumerBuffer::index > expectedChunkIndex: another consumer has rotated consumerBuffer,
                 // that has been pooled and reused again
                 //In both cases we have a stale view of the world with a not reliable next value.
+                final long expectedChunkIndex = chunkIndex - 1;
                 if (expectedChunkIndex != consumerBuffer.lvIndex())
                 {
                     continue;
                 }
+                next = consumerBuffer.lvNext();
+                //next could have been modified by another consumer, but:
+                //- if null: it still needs to check q empty + casConsumerIndex
+                //- if !null: it will fail on casConsumerIndex
                 if (next == null)
                 {
                     if (consumerIndex >= pIndex && // test against cached pIndex
@@ -532,6 +535,10 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcUnboundedXaddArrayQueueP
                             //stale view of the world
                             continue;
                         }
+                        //it cover both cases:
+                        //- right chunk, awaiting element to be set
+                        //- old chunk, awaiting rotation
+                        //It allows to fail fast if the q is empty after the first element on the new chunk.
                         if (consumerIndex >= pIndex && // test against cached pIndex
                             consumerIndex == (pIndex = lvProducerIndex()))
                         { // update pIndex if we must
@@ -541,15 +548,18 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcUnboundedXaddArrayQueueP
                         continue;
                     }
                 } else {
-                    e = consumerBuffer.lvElement(consumerOffset);
                     final long index = consumerBuffer.lvIndex();
-                    if (index != chunkIndex || e == null)
+                    if (index != chunkIndex || (e = consumerBuffer.lvElement(consumerOffset)) == null)
                     {
                         if (index > chunkIndex)
                         {
                             //stale view of the world
                             continue;
                         }
+                        //it cover both cases:
+                        //- right chunk, awaiting element to be set
+                        //- old chunk, awaiting rotation
+                        //It allows to fail fast if the q is empty after the first element on the new chunk.
                         if (consumerIndex >= pIndex && // test against cached pIndex
                             consumerIndex == (pIndex = lvProducerIndex()))
                         { // update pIndex if we must
@@ -668,9 +678,9 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcUnboundedXaddArrayQueueP
         final boolean firstElementOfNewChunk = consumerOffset == 0 && consumerIndex >= chunkSize;
         if (firstElementOfNewChunk)
         {
-            final AtomicChunk<E> next = consumerBuffer.lvNext();
             final long expectedChunkIndex = chunkIndex - 1;
-            if (expectedChunkIndex != consumerBuffer.lvIndex() || next == null)
+            final AtomicChunk<E> next;
+            if (expectedChunkIndex != consumerBuffer.lvIndex() || (next = consumerBuffer.lvNext()) == null)
             {
                 return null;
             }
@@ -704,7 +714,7 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcUnboundedXaddArrayQueueP
             next.soElement(consumerOffset, null);
             next.spPrev(null);
             //save from nepotism
-            consumerBuffer.spNext(null);
+            consumerBuffer.soNext(null);
             if (consumerBuffer.isPooled())
             {
                 final boolean offered = freeBuffer.offer(consumerBuffer);
@@ -728,9 +738,8 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcUnboundedXaddArrayQueueP
             }
             else
             {
-                e = consumerBuffer.lvElement(consumerOffset);
                 final long index = consumerBuffer.lvIndex();
-                if (index != chunkIndex || e == null)
+                if (index != chunkIndex || (e = consumerBuffer.lvElement(consumerOffset)) == null)
                 {
                     return null;
                 }

--- a/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddArrayQueue.java
@@ -498,7 +498,7 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcUnboundedXaddArrayQueueP
                 //  but not reused (yet, if possible)
                 //- consumerBuffer::index > expectedChunkIndex: another consumer has rotated consumerBuffer,
                 // that has been pooled and reused again
-                //In both cases we have a stale view of the world with a not reliable next value.
+                //in both cases we have a stale view of the world with a not reliable next value.
                 final long expectedChunkIndex = chunkIndex - 1;
                 if (expectedChunkIndex != consumerBuffer.lvIndex())
                 {
@@ -538,7 +538,7 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcUnboundedXaddArrayQueueP
                         //it cover both cases:
                         //- right chunk, awaiting element to be set
                         //- old chunk, awaiting rotation
-                        //It allows to fail fast if the q is empty after the first element on the new chunk.
+                        //it allows to fail fast if the q is empty after the first element on the new chunk.
                         if (consumerIndex >= pIndex && // test against cached pIndex
                             consumerIndex == (pIndex = lvProducerIndex()))
                         { // update pIndex if we must
@@ -559,7 +559,7 @@ public class MpmcUnboundedXaddArrayQueue<E> extends MpmcUnboundedXaddArrayQueueP
                         //it cover both cases:
                         //- right chunk, awaiting element to be set
                         //- old chunk, awaiting rotation
-                        //It allows to fail fast if the q is empty after the first element on the new chunk.
+                        //it allows to fail fast if the q is empty after the first element on the new chunk.
                         if (consumerIndex >= pIndex && // test against cached pIndex
                             consumerIndex == (pIndex = lvProducerIndex()))
                         { // update pIndex if we must

--- a/jctools-core/src/test/java/org/jctools/queues/MpqSanityTestMpmcUnboundedXadd.java
+++ b/jctools-core/src/test/java/org/jctools/queues/MpqSanityTestMpmcUnboundedXadd.java
@@ -22,6 +22,8 @@ public class MpqSanityTestMpmcUnboundedXadd extends MpqSanityTest
         ArrayList<Object[]> list = new ArrayList<Object[]>();
         list.add(makeMpq(0, 0, 0, Ordering.FIFO, new MpmcUnboundedXaddArrayQueue<>(1)));
         list.add(makeMpq(0, 0, 0, Ordering.FIFO, new MpmcUnboundedXaddArrayQueue<>(64)));
+        list.add(makeMpq(0, 0, 0, Ordering.FIFO, new MpmcUnboundedXaddArrayQueue<>(1, 2)));
+        list.add(makeMpq(0, 0, 0, Ordering.FIFO, new MpmcUnboundedXaddArrayQueue<>(64, 2)));
         return list;
     }
 

--- a/jctools-core/src/test/java/org/jctools/queues/QueueSanityTestMpmcUnboundedXadd.java
+++ b/jctools-core/src/test/java/org/jctools/queues/QueueSanityTestMpmcUnboundedXadd.java
@@ -25,6 +25,8 @@ public class QueueSanityTestMpmcUnboundedXadd extends QueueSanityTest
         ArrayList<Object[]> list = new ArrayList<Object[]>();
         list.add(makeQueue(0, 0, 0, Ordering.FIFO, new MpmcUnboundedXaddArrayQueue<>(1)));
         list.add(makeQueue(0, 0, 0, Ordering.FIFO, new MpmcUnboundedXaddArrayQueue<>(64)));
+        list.add(makeQueue(0, 0, 0, Ordering.FIFO, new MpmcUnboundedXaddArrayQueue<>(1, 2)));
+        list.add(makeQueue(0, 0, 0, Ordering.FIFO, new MpmcUnboundedXaddArrayQueue<>(64, 2)));
         return list;
     }
 


### PR DESCRIPTION
it provides a full-fat wait-free `relaxedPoll` for the mpmc xadd q.
Soon I will publish some results to check how/if it improves if compared with `poll`.
I'm not sure I will provide `relaxedPeek` unless strictly necessary.

My concern is that given the many indirections of this queue, a relaxedPoll won't give any perf benefit if not to be sure that the operation completes in a finite number of steps (as a wait-free one is expecting to do).