### PR TITLE
mpmc xadd q poll wasn't handling correctly chunkSize = 1 pooled case

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddChunk.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpmcUnboundedXaddChunk.java
@@ -40,11 +40,27 @@ final class MpmcUnboundedXaddChunk<E> extends MpUnboundedXaddChunk<MpmcUnbounded
 
     void soSequence(int index, long e)
     {
+        assert isPooled();
         soLongElement(sequence, calcLongElementOffset(index), e);
     }
 
     long lvSequence(int index)
     {
+        assert isPooled();
         return lvLongElement(sequence, calcLongElementOffset(index));
+    }
+
+    void spinForSequence(int index, long e)
+    {
+        assert isPooled();
+        final long[] sequence = this.sequence;
+        final long offset = calcLongElementOffset(index);
+        while (true)
+        {
+            if (lvLongElement(sequence, offset) == e)
+            {
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
QueueSanityTest::testSize with chunkSize = 1 and 1 recycled chunks was
failing with a blocked poll because it wasn't handling ccChunkIndex ==
ciChunkIndex as an isFirstElementOfNextChunk case