### PR TITLE
fix test case

### DIFF
--- a/jctools-core/src/test/java/org/jctools/queues/MpqSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/MpqSanityTest.java
@@ -1157,7 +1157,7 @@ public abstract class MpqSanityTest
                 if (q.offer(sequence)) {
                     sequence++;
                 }
-                Thread.yield();
+                TestUtil.sleepQuietly(1);
             }
         });
 

--- a/jctools-core/src/test/java/org/jctools/queues/MpqSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/MpqSanityTest.java
@@ -1157,7 +1157,7 @@ public abstract class MpqSanityTest
                 if (q.offer(sequence)) {
                     sequence++;
                 }
-                TestUtil.sleepQuietly(1);
+                Thread.yield();
             }
         });
 

--- a/jctools-core/src/test/java/org/jctools/queues/MpqSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/MpqSanityTest.java
@@ -1015,6 +1015,7 @@ public abstract class MpqSanityTest
         startWaitJoin(stop, producers, consumer);
 
         assertEquals("Observed no element in non-empty queue", 0, fail.value);
+        stop.set(false);
     }
 
     private void startWaitJoin(AtomicBoolean stop, Thread[] producers, Thread consumer) throws InterruptedException

--- a/jctools-core/src/test/java/org/jctools/queues/QueueSanityTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/QueueSanityTest.java
@@ -545,7 +545,7 @@ public abstract class QueueSanityTest
             while (!stop.get())
             {
                 // clear the top 8 bits
-                int nextVal = (i++ << 8) >> 8;
+                int nextVal = (i++ << 8) >>> 8;
                 // set the pid in the top 8 bits
                 q.offer(nextVal ^ pId);
             }
@@ -560,7 +560,7 @@ public abstract class QueueSanityTest
                 if (polledSequence == null) {
                     continue;
                 }
-                int pTid = polledSequence >> 24;
+                int pTid = polledSequence >>> 24;
                 if (lastPolledSequence[pTid] != null && polledSequence - lastPolledSequence[pTid] < 0) {
                     fail.value++;
                 }
@@ -593,7 +593,7 @@ public abstract class QueueSanityTest
             while (!stop.get())
             {
                 // clear the top 8 bits
-                int nextVal = (i++ << 8) >> 8;
+                int nextVal = (i++ << 8) >>> 8;
                 // set the pid in the top 8 bits
                 q.offer(nextVal ^ pId);
             }
@@ -617,7 +617,7 @@ public abstract class QueueSanityTest
                 if (peekedSequence == null) {
                     continue;
                 }
-                int pTid = peekedSequence >> 24;
+                int pTid = peekedSequence >>> 24;
                 if (lastPeekedSequence[pTid] != null && peekedSequence - lastPeekedSequence[pTid] < 0) {
                     fail.value++;
                 }


### PR DESCRIPTION
1. revert `testIsEmptyInvariant`
2. fix IndexOutOfBoundsException caused by `testPollOrderContendedFull` and `testPeekOrderContendedFull`