### PR TITLE
remove some redundant fence

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java
@@ -351,7 +351,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
             return newBufferPoll(nextBuffer, index);
         }
 
-        soRefElement(buffer, offset, null); // release element null
+        spRefElement(buffer, offset, null); // release element null
         soConsumerIndex(index + 2); // release cIndex
         return (E) e;
     }
@@ -457,7 +457,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
         {
             throw new IllegalStateException("new buffer must have at least one element");
         }
-        soRefElement(nextBuffer, offset, null);
+        spRefElement(nextBuffer, offset, null);
         soConsumerIndex(index + 2);
         return n;
     }
@@ -513,7 +513,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
             final E[] nextBuffer = nextBuffer(buffer, mask);
             return newBufferPoll(nextBuffer, index);
         }
-        soRefElement(buffer, offset, null);
+        spRefElement(buffer, offset, null);
         soConsumerIndex(index + 2);
         return (E) e;
     }
@@ -753,7 +753,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
 
     private void resize(long oldMask, E[] oldBuffer, long pIndex, E e, Supplier<E> s)
     {
-        assert (e != null && s == null) || (e == null || s != null);
+        assert (e != null && s == null) || (e == null && s != null);
         int newBufferLength = getNextBufferSize(oldBuffer);
         final E[] newBuffer;
         try
@@ -774,8 +774,9 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
         final long offsetInOld = modifiedCalcCircularRefElementOffset(pIndex, oldMask);
         final long offsetInNew = modifiedCalcCircularRefElementOffset(pIndex, newMask);
 
-        soRefElement(newBuffer, offsetInNew, e == null ? s.get() : e);// element in new array
-        soRefElement(oldBuffer, nextArrayOffset(oldMask), newBuffer);// buffer linked
+        // Plain Mode: unreachable until soProducerIndex
+        spRefElement(newBuffer, offsetInNew, e == null ? s.get() : e);// element in new array
+        spRefElement(oldBuffer, nextArrayOffset(oldMask), newBuffer);// buffer linked
 
         // ASSERT code
         final long cIndex = lvConsumerIndex();

--- a/jctools-core/src/main/java/org/jctools/queues/BaseSpscLinkedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/BaseSpscLinkedArrayQueue.java
@@ -172,10 +172,10 @@ abstract class BaseSpscLinkedArrayQueue<E> extends BaseSpscLinkedArrayQueueProdu
         return lvConsumerIndex();
     }
 
-    protected final void soNext(E[] curr, E[] next)
+    protected final void spNext(E[] curr, E[] next)
     {
         long offset = nextArrayOffset(curr);
-        soRefElement(curr, offset, next);
+        spRefElement(curr, offset, next);
     }
 
     @SuppressWarnings("unchecked")
@@ -374,9 +374,11 @@ abstract class BaseSpscLinkedArrayQueue<E> extends BaseSpscLinkedArrayQueueProdu
         final E[] newBuffer, final long offsetInNew,
         final E e)
     {
-        soRefElement(newBuffer, offsetInNew, e);
+        // Plain Mode: unreachable until JUMP is published
+        spRefElement(newBuffer, offsetInNew, e);
         // link to next buffer and add next indicator as element of old buffer
-        soNext(oldBuffer, newBuffer);
+        spNext(oldBuffer, newBuffer);
+
         soRefElement(oldBuffer, offset, JUMP);
         // index is visible after elements (isEmpty/poll ordering)
         soProducerIndex(currIndex + 1);// this ensures atomic write of long on 32bit platforms


### PR DESCRIPTION
1. For MpscLinkedArrayQueue, producer rely on consumerIndex.
2. For MpscLinkedArrayQueue, newBuffer is unreachable until soProducerIndex.
3. For SpscLinkedArrayQueue, newBuffer is unreachable  until soRefElement(JUMP)
4. Fix resize assertion