### PR TITLE
remove some redundant fence

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/MpUnboundedXaddChunk.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpUnboundedXaddChunk.java
@@ -80,6 +80,10 @@ class MpUnboundedXaddChunk<R,E>
         return lvRefElement(buffer, calcRefElementOffset(index));
     }
 
+    final void spElement(int index, E e) {
+        spRefElement(buffer, calcRefElementOffset(index), e);
+    }
+
     final E spinForElement(int index, boolean isNull)
     {
         E[] buffer = this.buffer;

--- a/jctools-core/src/main/java/org/jctools/queues/MpscUnboundedXaddArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpscUnboundedXaddArrayQueue.java
@@ -137,7 +137,8 @@ public class MpscUnboundedXaddArrayQueue<E> extends MpUnboundedXaddArrayQueue<Mp
                 e = cChunk.spinForElement(ciChunkOffset, false);
             }
         }
-        cChunk.soElement(ciChunkOffset, null);
+        // consumer free the chunk happens-before producer reuse the chunk
+        cChunk.spElement(ciChunkOffset, null);
         soConsumerIndex(cIndex + 1);
         return e;
     }
@@ -212,7 +213,8 @@ public class MpscUnboundedXaddArrayQueue<E> extends MpUnboundedXaddArrayQueue<Mp
             }
         }
 
-        cChunk.soElement(ciChunkOffset, null);
+        // consumer free the chunk happens-before producer reuse the chunk
+        cChunk.spElement(ciChunkOffset, null);
         soConsumerIndex(cIndex + 1);
         return e;
     }
@@ -303,7 +305,8 @@ public class MpscUnboundedXaddArrayQueue<E> extends MpUnboundedXaddArrayQueue<Mp
                     return i;
                 }
             }
-            cChunk.soElement(consumerOffset, null);
+            // consumer free the chunk happens-before producer reuse the chunk
+            cChunk.spElement(consumerOffset, null);
             final long nextConsumerIndex = cIndex + 1;
             soConsumerIndex(nextConsumerIndex);
             c.accept(e);

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicQueueUtil.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/AtomicQueueUtil.java
@@ -15,7 +15,7 @@ final class AtomicQueueUtil
         return buffer.get(offset); // no weaker form available
     }
 
-    static <E> void spRefElement(AtomicReferenceArray<E> buffer, int offset, E value)
+    static void spRefElement(AtomicReferenceArray buffer, int offset, Object value)
     {
         buffer.lazySet(offset, value);  // no weaker form available
     }

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/BaseMpscLinkedAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/BaseMpscLinkedAtomicArrayQueue.java
@@ -428,7 +428,7 @@ abstract class BaseMpscLinkedAtomicArrayQueue<E> extends BaseMpscLinkedAtomicArr
             return newBufferPoll(nextBuffer, index);
         }
         // release element null
-        soRefElement(buffer, offset, null);
+        spRefElement(buffer, offset, null);
         // release cIndex
         soConsumerIndex(index + 2);
         return (E) e;
@@ -494,8 +494,9 @@ abstract class BaseMpscLinkedAtomicArrayQueue<E> extends BaseMpscLinkedAtomicArr
 
     @SuppressWarnings("unchecked")
     private AtomicReferenceArray<E> nextBuffer(final AtomicReferenceArray<E> buffer, final long mask) {
+        // this access after loadVolatile JUMP
         final int offset = nextArrayOffset(mask);
-        final AtomicReferenceArray<E> nextBuffer = (AtomicReferenceArray<E>) lvRefElement(buffer, offset);
+        final AtomicReferenceArray<E> nextBuffer = (AtomicReferenceArray<E>) lpRefElement(buffer, offset);
         consumerBuffer = nextBuffer;
         consumerMask = (length(nextBuffer) - 2) << 1;
         soRefElement(buffer, offset, BUFFER_CONSUMED);
@@ -507,19 +508,21 @@ abstract class BaseMpscLinkedAtomicArrayQueue<E> extends BaseMpscLinkedAtomicArr
     }
 
     private E newBufferPoll(AtomicReferenceArray<E> nextBuffer, long index) {
+        // this access after loadVolatile JUMP
         final int offset = modifiedCalcCircularRefElementOffset(index, consumerMask);
-        final E n = lvRefElement(nextBuffer, offset);
+        final E n = lpRefElement(nextBuffer, offset);
         if (n == null) {
             throw new IllegalStateException("new buffer must have at least one element");
         }
-        soRefElement(nextBuffer, offset, null);
+        spRefElement(nextBuffer, offset, null);
         soConsumerIndex(index + 2);
         return n;
     }
 
     private E newBufferPeek(AtomicReferenceArray<E> nextBuffer, long index) {
+        // this access after loadVolatile JUMP
         final int offset = modifiedCalcCircularRefElementOffset(index, consumerMask);
-        final E n = lvRefElement(nextBuffer, offset);
+        final E n = lpRefElement(nextBuffer, offset);
         if (null == n) {
             throw new IllegalStateException("new buffer must have at least one element");
         }
@@ -559,7 +562,7 @@ abstract class BaseMpscLinkedAtomicArrayQueue<E> extends BaseMpscLinkedAtomicArr
             final AtomicReferenceArray<E> nextBuffer = nextBuffer(buffer, mask);
             return newBufferPoll(nextBuffer, index);
         }
-        soRefElement(buffer, offset, null);
+        spRefElement(buffer, offset, null);
         soConsumerIndex(index + 2);
         return (E) e;
     }
@@ -766,7 +769,7 @@ abstract class BaseMpscLinkedAtomicArrayQueue<E> extends BaseMpscLinkedAtomicArr
     }
 
     private void resize(long oldMask, AtomicReferenceArray<E> oldBuffer, long pIndex, E e, Supplier<E> s) {
-        assert (e != null && s == null) || (e == null || s != null);
+        assert (e != null && s == null) || (e == null && s != null);
         int newBufferLength = getNextBufferSize(oldBuffer);
         final AtomicReferenceArray<E> newBuffer;
         try {
@@ -781,10 +784,11 @@ abstract class BaseMpscLinkedAtomicArrayQueue<E> extends BaseMpscLinkedAtomicArr
         producerMask = newMask;
         final int offsetInOld = modifiedCalcCircularRefElementOffset(pIndex, oldMask);
         final int offsetInNew = modifiedCalcCircularRefElementOffset(pIndex, newMask);
+        // Plain Mode: unreachable until soProducerIndex
         // element in new array
-        soRefElement(newBuffer, offsetInNew, e == null ? s.get() : e);
+        spRefElement(newBuffer, offsetInNew, e == null ? s.get() : e);
         // buffer linked
-        soRefElement(oldBuffer, nextArrayOffset(oldMask), newBuffer);
+        spRefElement(oldBuffer, nextArrayOffset(oldMask), newBuffer);
         // ASSERT code
         final long cIndex = lvConsumerIndex();
         final long availableInQueue = availableInQueue(pIndex, cIndex);


### PR DESCRIPTION
1. For MpscLinkedArrayQueue, producer(producerLimit) rely on consumerIndex.
2. For MpscLinkedArrayQueue, newBuffer is unreachable until soProducerIndex.
3. For SpscLinkedArrayQueue, newBuffer is unreachable  until soRefElement(JUMP).
4. Fix resize assertion.
5. For MpscUnboundedXaddArrayQueue, consumer free the chunk happens-before producer reuse the chunk.

I have run related tests.