### PR TITLE
Add a wait-free intrusive stack data structure

### DIFF
--- a/jctools-experimental/src/main/java/org/jctools/stacks/ConcurrentLinkedStack.java
+++ b/jctools-experimental/src/main/java/org/jctools/stacks/ConcurrentLinkedStack.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.stacks;
+
+import java.util.Iterator;
+
+/**
+ * A concurrent, unbounded, and non-blocking stack based on linked nodes.
+ * Concurrent push and pop executes safely across multiple threads.
+ * <p>
+ * Unlike {@code java.util.concurrent.ConcurrentLinkedDeque}, this class only supports
+ * the stack APIs, and does not support internal-remove.
+ * On the other hand, this class has a constant time {@link #size()} method,
+ * and a wait-free {@link #push(Object)} method.
+ * <p>
+ * The {@link #iterator()} operates on a safely captured snapshot of the stack,
+ * and is <em>weakly consistent</em>. This follows the precedent of the
+ * {@code java.util.concurrent} package, as defined in its package summary.
+ * <p>
+ * This implementation is based on the {@link WFIStack}.
+ */
+public class ConcurrentLinkedStack<T> implements Iterable<T>
+{
+    private final WFIStack<LinkedNode<T>> stack;
+
+    /**
+     * Create a new empty stack.
+     */
+    public ConcurrentLinkedStack()
+    {
+        stack = new WFIStack<LinkedNode<T>>();
+    }
+
+    /**
+     * Push the given object onto the stack.
+     *
+     * @param value The object to push onto the stack.
+     */
+    public void push(T value)
+    {
+        stack.push(new LinkedNode<T>(value));
+    }
+
+    /**
+     * Pop the top-most object from the stack.
+     *
+     * @return The object that was the head of the stack, or {@code null} if the stack was empty.
+     */
+    public T pop()
+    {
+        LinkedNode<T> node = stack.pop();
+        return node == null ? null : node.value;
+    }
+
+    /**
+     * Peek at the top of the stack, without removing said object.
+     * <p>
+     * Note that the result may be outdated as soon as this method returns.
+     *
+     * @return The object that is the top of the stack, or {@code null} if the stack is empty.
+     */
+    public T peek()
+    {
+        LinkedNode<T> node = stack.peek();
+        return node == null ? null : node.value;
+    }
+
+    /**
+     * Get the size of the stack.
+     *
+     * @return The number of objects on this stack.
+     */
+    public int size()
+    {
+        return stack.size();
+    }
+
+    /**
+     * Tell whether the stack is empty.
+     *
+     * @return {@code true} if the stack is empty.
+     */
+    public boolean isEmpty()
+    {
+        return stack.isEmpty();
+    }
+
+    @Override
+    public Iterator<T> iterator()
+    {
+        return new Iterator<T>()
+        {
+            private final Iterator<LinkedNode<T>> inner = stack.iterator();
+
+            @Override
+            public boolean hasNext()
+            {
+                return inner.hasNext();
+            }
+
+            @Override
+            public T next()
+            {
+                LinkedNode<T> next = inner.next();
+                return next.value;
+            }
+        };
+    }
+
+    private static class LinkedNode<T> extends WFIStack.Node
+    {
+        private final T value;
+
+        private LinkedNode(T value)
+        {
+            this.value = value;
+        }
+    }
+}

--- a/jctools-experimental/src/main/java/org/jctools/stacks/WFIStack.java
+++ b/jctools-experimental/src/main/java/org/jctools/stacks/WFIStack.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.stacks;
+
+import org.jctools.util.UnsafeAccess;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * A Wait-Free Intrusive Stack (Last-In, First-Out).
+ * <p>
+ * This stack has wait-free push, and wait-free bulk pop and bulk replace operations.
+ * The single-item pop operation is non-blocking but not wait-free.
+ * <p>
+ * The stack supports multiple concurrent consumers and multiple concurrent producers.
+ * <p>
+ * The stack is intrusive, and implementors must extend the {@link Node} class in order to use the stack.
+ * These node objects cannot be reused, and must be allocated fresh for every push.
+ * <p>
+ * The implementation draws inspiration from Dmitry Vyukov's
+ * <a href="http://www.1024cores.net/home/lock-free-algorithms/queues/intrusive-mpsc-node-based-queue">
+ * Intrusive MPSC node-based queue</a>, but is oriented as a stack instead of a queue, and supports MPMC.
+ *
+ * @param <T> The type of node in this stack.
+ */
+@SuppressWarnings({"unchecked", "NullableProblems"})
+public class WFIStack<T extends WFIStack.Node> implements Iterable<T>
+{
+    /**
+     * The super-class of all nodes, or entries, for {@link WFIStack wait-free intrusive stacks}.
+     */
+    public static abstract class Node
+    {
+        volatile Node next;
+        int count;
+
+        final Node next()
+        {
+            Node n = next;
+            while (n == null)
+            {
+                // TODO: Thread.onSpinWait
+                Thread.yield();
+                n = next;
+            }
+            return n;
+        }
+
+        <X extends Node> X self()
+        {
+            return (X) this;
+        }
+    }
+
+    private static class NodeIterable<E extends Node> implements Iterable<E>
+    {
+        private Node start;
+
+        private NodeIterable(Node start)
+        {
+            this.start = start;
+        }
+
+        @Override
+        public Iterator<E> iterator()
+        {
+            return new NodeIterator<E>(start);
+        }
+
+        public NodeIterable<E> reverse()
+        {
+            Node curr = END;
+            Node next = start;
+            while (next != END)
+            {
+                Node n = next;
+                next = next.next();
+                n.next = curr;
+                curr = n;
+            }
+            start = curr;
+            return this;
+        }
+    }
+
+    private static class NodeIterator<E extends Node> implements Iterator<E>
+    {
+        Node next;
+
+        public NodeIterator(Node start)
+        {
+            next = start.self();
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return next != null;
+        }
+
+        @Override
+        public E next()
+        {
+            Node n = next;
+            if (n == null)
+            {
+                throw new NoSuchElementException();
+            }
+            next = n.next().self();
+            return (E) n;
+        }
+    }
+
+    private static final Node END = new Node()
+    {
+        {
+            next = this; // Next from END is END itself.
+        }
+
+        @Override
+        <X extends Node> X self()
+        {
+            return null;
+        }
+    };
+    private static final long HEAD_OFFSET = UnsafeAccess.fieldOffset(WFIStack.class, "head");
+
+    @SuppressWarnings( {"FieldCanBeLocal", "FieldMayBeFinal"})
+    private volatile Node head; // Accessed via UNSAFE.
+
+    /**
+     * Create an empty wait-free intrusive stack.
+     */
+    public WFIStack()
+    {
+        if (!UnsafeAccess.SUPPORTS_GET_AND_SET_REF)
+        {
+            throw new IllegalStateException(
+                "Unsafe::getAndSetObject support (JDK 8+) is required for this stack to work.");
+        }
+        head = END;
+    }
+
+    /**
+     * Get the size of the stack.
+     * This is the number of elements currently pushed onto the stack.
+     * Note that this method is inherently racy, and the number can be outdated as soon as it is returned.
+     *
+     * @return The number of elements in the stack.
+     */
+    public int size()
+    {
+        Node h = head; // Take snapshot of stack.
+        h.next(); // Ensure 'count' has been updated, by ensuring 'next' has been updated.
+        return h.count;
+    }
+
+    /**
+     * Peek at the head of the stack.
+     * This returns the most recently added element, if any.
+     * Note that this method is inherently racy, and the value can be outdated as soon as it is returned.
+     *
+     * @return The most recently added element, or {@code null}.
+     */
+    public T peek()
+    {
+        return head.self();
+    }
+
+    /**
+     * Push the given node onto the head of the stack.
+     * <p>
+     * This operation is wait-free and has constant time-complexity.
+     *
+     * @param node The node to push onto the stack.
+     */
+    public void push(T node)
+    {
+        checkPush(node);
+        T n = xchgHead(node);
+        node.count = n.count + 1; // Update 'count' before volatile store to 'next'.
+        node.next = n;
+    }
+
+    /**
+     * Atomically peek the head of the stack, and push the given node onto the head of the stack.
+     * The returned node is the head of the stack that was displaced by the given pushed node.
+     * The returned node is not removed from the stack, so the size of the stack is increased by one.
+     * <p>
+     * This operation is wait-free and has constant time-complexity.
+     *
+     * @param node The node to push onto the stack.
+     * @return The node that was previously the head of the stack, if any, or {@code null} if the stack was empty.
+     */
+    public T peekAndPush(T node)
+    {
+        checkPush(node);
+        T n = xchgHead(node);
+        node.count = n.count + 1; // Update 'count' before volatile store to 'next'.
+        node.next = n;
+        return n.self();
+    }
+
+    /**
+     * Remove all nodes from the stack, and return an iterable of the removed nodes.
+     * The returned iterable is a complete and atomic snapshot of the stack contents at the time of the method call.
+     * Racing callers will not see any overlap between their returned iterables.
+     * The iterable is re-entrant, so {@link Iterable#iterator()} can be called on it multiple times, and it will
+     * always produce the same result.
+     * <p>
+     * This operation is wait-free and has constant time-complexity.
+     *
+     * @return An iterable of all the nodes in the stack.
+     */
+    public Iterable<T> popAll()
+    {
+        return new NodeIterable<T>(xchgHead(END));
+    }
+
+    /**
+     * Remove all nodes from the stack, and return an iterable of the removed nodes.
+     * The returned iterable is a complete and atomic snapshot of the stack contents at the time of the method call.
+     * Racing callers will not see any overlap between their returned iterables.
+     * The iterable is re-entrant, so {@link Iterable#iterator()} can be called on it multiple times, and it will
+     * always produce the same result.
+     * <p>
+     * This operation is wait-free and has time-complexity linear to the number of elements in the returned iterable.
+     *
+     * @return An iterable of all the nodes in the stack.
+     */
+    public Iterable<T> popAllFifo()
+    {
+        return new NodeIterable<T>(xchgHead(END)).reverse();
+    }
+
+    /**
+     * Replaces and returns all nodes in the stack with the given node, and return an iterable of the removed nodes.
+     * The returned iterable is a complete and atomic snapshot of the stack contents at the time of the method call.
+     * Racing callers will not see any overlap between their returned iterables.
+     * The iterable is re-entrant, so {@link Iterable#iterator()} can be called on it multiple times, and it will
+     * always produce the same result.
+     * <p>
+     * This operation is wait-free and has constant time-complexity.
+     *
+     * @return An iterable of all the nodes in the stack, in Last In, First Out order.
+     */
+    public Iterable<T> replaceAll(T node)
+    {
+        checkPush(node);
+        node.count = 1;
+        node.next = END;
+        return new NodeIterable<T>(xchgHead(node));
+    }
+
+
+    /**
+     * Replaces and returns all nodes in the stack with the given node, and return an iterable of the removed nodes.
+     * The returned iterable is a complete and atomic snapshot of the stack contents at the time of the method call.
+     * Racing callers will not see any overlap between their returned iterables.
+     * The iterable is re-entrant, so {@link Iterable#iterator()} can be called on it multiple times, and it will
+     * always produce the same result.
+     * <p>
+     * This operation is wait-free and has time-complexity linear to the number of elements in the returned iterable.
+     *
+     * @return An iterable of all the nodes in the stack, in First In, First Out order.
+     */
+    public Iterable<T> replaceAllFifo(T node)
+    {
+        checkPush(node);
+        node.count = 1;
+        node.next = END;
+        return new NodeIterable<T>(xchgHead(node)).reverse();
+    }
+
+    /**
+     * Pop, or remove, the most recently pushed node, or return {@code null} if the stack is empty.
+     * <p>
+     * This operation is non-blocking, but not wait-free. It has constant time-complexity.
+     *
+     * @return The most recently pushed node, if any, or {@code null}.
+     */
+    public T pop()
+    {
+        Node candidate, successor;
+        do
+        {
+            candidate = head;
+            if (candidate == END)
+            {
+                return null;
+            }
+            successor = candidate.next();
+        }
+        while (!casHead(candidate, successor));
+        return candidate.self();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new NodeIterator<T>(head);
+    }
+
+    private void checkPush(T node)
+    {
+        assert node.next == null : "WFIStack.Nodes cannot be reused.";
+    }
+
+    private T xchgHead(Node node)
+    {
+        return (T) UnsafeAccess.UNSAFE.getAndSetObject(this, HEAD_OFFSET, node);
+    }
+
+    private boolean casHead(Node expected, Node update)
+    {
+        return UnsafeAccess.UNSAFE.compareAndSwapObject(this, HEAD_OFFSET, expected, update);
+    }
+}

--- a/jctools-experimental/src/main/java/org/jctools/stacks/WFIStack.java
+++ b/jctools-experimental/src/main/java/org/jctools/stacks/WFIStack.java
@@ -165,6 +165,16 @@ public class WFIStack<T extends WFIStack.Node> extends PadAfter implements Itera
     }
 
     /**
+     * Returns {@code true} if the stack contains no elements.
+     *
+     * @return {@code true} if the stack contains no elements.
+     */
+    public boolean isEmpty()
+    {
+        return head == END;
+    }
+
+    /**
      * Peek at the head of the stack.
      * This returns the most recently added element, if any.
      * Note that this method is inherently racy, and the value can be outdated as soon as it is returned.

--- a/jctools-experimental/src/main/java/org/jctools/stacks/WFIStack.java
+++ b/jctools-experimental/src/main/java/org/jctools/stacks/WFIStack.java
@@ -342,7 +342,7 @@ public class WFIStack<T extends Node> extends WFIStackL1Pad implements Iterable<
     /**
      * Pop, or remove, the most recently pushed node, or return {@code null} if the stack is empty.
      * <p>
-     * This operation is non-blocking, but not wait-free. It has constant time-complexity.
+     * This operation is lock-free, but not wait-free.
      *
      * @return The most recently pushed node, if any, or {@code null}.
      */

--- a/jctools-experimental/src/test/java/org/jctools/stacks/ConcurrentLinkedStackTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/stacks/ConcurrentLinkedStackTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.stacks;
+
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+/**
+ * @see WFIStackTest most of the correctness of this implementation is derived from the WFIStack.
+ */
+public class ConcurrentLinkedStackTest
+{
+    @Test
+    public void sanityCheckMethods()
+    {
+        ConcurrentLinkedStack<Object> stack = new ConcurrentLinkedStack<Object>();
+        assertTrue(stack.isEmpty());
+        assertEquals(0, stack.size());
+        assertFalse(stack.iterator().hasNext());
+        assertNull(stack.pop());
+        assertNull(stack.peek());
+
+        stack.push(1);
+
+        assertEquals(1, stack.peek());
+        assertFalse(stack.isEmpty());
+        assertEquals(1, stack.size());
+        Iterator<Object> iterator = stack.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(1, iterator.next());
+        assertFalse(iterator.hasNext());
+
+        assertEquals(1, stack.pop());
+
+        assertTrue(stack.isEmpty());
+        assertEquals(0, stack.size());
+        assertFalse(stack.iterator().hasNext());
+        assertNull(stack.pop());
+        assertNull(stack.peek());
+
+        stack.push(2);
+        stack.push(3);
+
+        assertFalse(stack.isEmpty());
+        assertEquals(2, stack.size());
+        iterator = stack.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(3, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(2, iterator.next());
+        assertFalse(iterator.hasNext());
+        assertEquals(3, stack.peek());
+
+        assertEquals(3, stack.pop());
+
+        assertEquals(2, stack.peek());
+
+        assertEquals(2, stack.pop());
+
+        assertTrue(stack.isEmpty());
+        assertEquals(0, stack.size());
+        assertFalse(stack.iterator().hasNext());
+        assertNull(stack.pop());
+        assertNull(stack.peek());
+    }
+}

--- a/jctools-experimental/src/test/java/org/jctools/stacks/WFIStackTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/stacks/WFIStackTest.java
@@ -1,0 +1,395 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.stacks;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.*;
+
+public class WFIStackTest
+{
+    private static class IntNode extends WFIStack.Node
+    {
+        final int value;
+
+        private IntNode(int value)
+        {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass())
+            {
+                return false;
+            }
+
+            IntNode intNode = (IntNode) o;
+            return value == intNode.value;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return value;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "IntNode{" +
+                "value=" + value +
+                '}';
+        }
+    }
+
+    private WFIStack<IntNode> stack;
+
+    @Before
+    public void setUp()
+    {
+        stack = new WFIStack<>();
+    }
+
+    @Test
+    public void pushAndPop()
+    {
+        assertNull(stack.pop());
+        stack.push(new IntNode(1));
+        stack.push(new IntNode(2));
+        assertEquals(stack.pop(), new IntNode(2));
+        assertEquals(stack.pop(), new IntNode(1));
+        assertNull(stack.pop());
+        stack.push(new IntNode(1));
+        assertEquals(stack.pop(), new IntNode(1));
+        assertNull(stack.pop());
+    }
+
+    @Test
+    public void peekAndPush()
+    {
+        assertNull(stack.peekAndPush(new IntNode(1)));
+        assertEquals(stack.peekAndPush(new IntNode(2)), new IntNode(1));
+        assertEquals(stack.peekAndPush(new IntNode(3)), new IntNode(2));
+        assertEquals(stack.size(), 3);
+        assertEquals(stack.pop(), new IntNode(3));
+        assertEquals(stack.pop(), new IntNode(2));
+        assertEquals(stack.pop(), new IntNode(1));
+        assertNull(stack.pop());
+    }
+
+    @Test
+    public void pushAndPopAll()
+    {
+        assertEquals(stack.size(), 0);
+        stack.push(new IntNode(1));
+        assertEquals(stack.size(), 1);
+        stack.push(new IntNode(2));
+        assertEquals(stack.size(), 2);
+        stack.push(new IntNode(3));
+        assertEquals(stack.size(), 3);
+
+        Iterable<IntNode> all = stack.popAll();
+        assertEquals(stack.size(), 0);
+        Iterator<IntNode> iterator = all.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(3));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(2));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertFalse(iterator.hasNext());
+
+        // Iterable must be reentrant.
+        iterator = all.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(3));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(2));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertFalse(iterator.hasNext());
+
+        try
+        {
+            iterator.next();
+            fail("Expected NoSuchElementException");
+        }
+        catch (NoSuchElementException ignore)
+        {
+            // Good.
+        }
+    }
+
+    @Test
+    public void pushAndPopAllFifo()
+    {
+        assertEquals(stack.size(), 0);
+        stack.push(new IntNode(1));
+        assertEquals(stack.size(), 1);
+        stack.push(new IntNode(2));
+        assertEquals(stack.size(), 2);
+        stack.push(new IntNode(3));
+        assertEquals(stack.size(), 3);
+
+        Iterable<IntNode> all = stack.popAllFifo();
+        assertEquals(stack.size(), 0);
+        Iterator<IntNode> iterator = all.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(2));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(3));
+        assertFalse(iterator.hasNext());
+
+        // Iterable must be reentrant.
+        iterator = all.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(2));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(3));
+        assertFalse(iterator.hasNext());
+
+        try
+        {
+            iterator.next();
+            fail("Expected NoSuchElementException");
+        }
+        catch (NoSuchElementException ignore)
+        {
+            // Good.
+        }
+    }
+
+    @Test
+    public void pushAndReplaceAll()
+    {
+        stack.push(new IntNode(1));
+        stack.push(new IntNode(2));
+        stack.push(new IntNode(3));
+
+        assertEquals(stack.size(), 3);
+        Iterable<IntNode> all = stack.replaceAll(new IntNode(4));
+        assertEquals(stack.size(), 1);
+        Iterator<IntNode> iterator = all.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(3));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(2));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertFalse(iterator.hasNext());
+
+        // Iterable must be reentrant.
+        iterator = all.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(3));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(2));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertFalse(iterator.hasNext());
+
+        try
+        {
+            iterator.next();
+            fail("Expected NoSuchElementException");
+        }
+        catch (NoSuchElementException ignore)
+        {
+            // Good.
+        }
+
+        assertEquals(stack.pop(), new IntNode(4));
+        assertNull(stack.pop());
+    }
+
+    @Test
+    public void pushAndReplaceAllFifo()
+    {
+        stack.push(new IntNode(1));
+        stack.push(new IntNode(2));
+        stack.push(new IntNode(3));
+
+        assertEquals(stack.size(), 3);
+        Iterable<IntNode> all = stack.replaceAllFifo(new IntNode(4));
+        assertEquals(stack.size(), 1);
+        Iterator<IntNode> iterator = all.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(2));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(3));
+        assertFalse(iterator.hasNext());
+
+        // Iterable must be reentrant.
+        iterator = all.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(2));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(3));
+        assertFalse(iterator.hasNext());
+
+        try
+        {
+            iterator.next();
+            fail("Expected NoSuchElementException");
+        }
+        catch (NoSuchElementException ignore)
+        {
+            // Good.
+        }
+
+        assertEquals(stack.pop(), new IntNode(4));
+        assertNull(stack.pop());
+    }
+
+    @Test
+    public void recyclingNodesOnPushMustThrow()
+    {
+        assertEquals(stack.size(), 0);
+        stack.push(new IntNode(1));
+        assertEquals(stack.size(), 1);
+        IntNode node = stack.pop();
+        assertEquals(stack.size(), 0);
+        boolean gotError = false;
+        try
+        {
+            stack.push(node);
+        }
+        catch (AssertionError ignore)
+        {
+            // Good.
+            gotError = true;
+        }
+        assertTrue(gotError);
+    }
+
+    @Test
+    public void recyclingNodesOnReplaceAllMustThrow()
+    {
+        assertEquals(stack.size(), 0);
+        stack.push(new IntNode(1));
+        assertEquals(stack.size(), 1);
+        IntNode node = stack.pop();
+        assertEquals(stack.size(), 0);
+        boolean gotError = false;
+        try
+        {
+            stack.replaceAll(node);
+        }
+        catch (AssertionError ignore)
+        {
+            // Good.
+            gotError = true;
+        }
+        assertTrue(gotError);
+    }
+
+    @Test
+    public void recyclingNodesOnReplaceAllFifoMustThrow()
+    {
+        assertEquals(stack.size(), 0);
+        stack.push(new IntNode(1));
+        assertEquals(stack.size(), 1);
+        IntNode node = stack.pop();
+        assertEquals(stack.size(), 0);
+        boolean gotError = false;
+        try
+        {
+            stack.replaceAllFifo(node);
+        }
+        catch (AssertionError ignore)
+        {
+            // Good.
+            gotError = true;
+        }
+        assertTrue(gotError);
+    }
+
+    @Test
+    public void peek() {
+        assertNull(stack.peek());
+        stack.push(new IntNode(1));
+        assertEquals(stack.peek(), new IntNode(1));
+        assertEquals(stack.peek(), new IntNode(1));
+        stack.push(new IntNode(2));
+        assertEquals(stack.peek(), new IntNode(2));
+        assertEquals(stack.peek(), new IntNode(2));
+        stack.replaceAll(new IntNode(3));
+        assertEquals(stack.peek(), new IntNode(3));
+        assertEquals(stack.peek(), new IntNode(3));
+        stack.replaceAllFifo(new IntNode(4));
+        assertEquals(stack.peek(), new IntNode(4));
+        assertEquals(stack.peek(), new IntNode(4));
+        stack.popAll();
+        assertNull(stack.peek());
+    }
+
+    @Test
+    public void iteration()
+    {
+        Iterator<IntNode> iterator = stack.iterator();
+        assertEmpty(iterator);
+
+        stack.push(new IntNode(1));
+        iterator = stack.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertEmpty(iterator);
+
+        iterator = stack.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertEmpty(iterator);
+
+        stack.push(new IntNode(2));
+
+        iterator = stack.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(2));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), new IntNode(1));
+        assertEmpty(iterator);
+    }
+
+    private void assertEmpty(Iterator<IntNode> iterator)
+    {
+        assertFalse(iterator.hasNext());
+        try
+        {
+            iterator.next();
+            fail("iterator.next() should throw when empty.");
+        }
+        catch (NoSuchElementException ignore)
+        {
+            // Good.
+        }
+    }
+}

--- a/jctools-experimental/src/test/java/org/jctools/stacks/WFIStackTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/stacks/WFIStackTest.java
@@ -506,7 +506,7 @@ public class WFIStackTest
 
         Arrays.sort(values);
         assertEquals(max, values[values.length - 1]);
-        assertEquals(values.length, valuesPerThread * pusherCount);
+        assertEquals(values.length, valuesPerThread * (long) pusherCount);
         for (int i = 1; i < values.length; i++)
         {
             assertEquals(values[i - 1] + 1, values[i]);

--- a/jctools-experimental/src/test/java/org/jctools/stacks/WFIStackTest.java
+++ b/jctools-experimental/src/test/java/org/jctools/stacks/WFIStackTest.java
@@ -75,8 +75,14 @@ public class WFIStackTest
     @Test
     public void pushAndPop()
     {
+        assertTrue(stack.isEmpty());
+        assertEquals(stack.size(), 0);
         assertNull(stack.pop());
+        assertTrue(stack.isEmpty());
+        assertEquals(stack.size(), 0);
         stack.push(new IntNode(1));
+        assertFalse(stack.isEmpty());
+        assertEquals(stack.size(), 1);
         stack.push(new IntNode(2));
         assertEquals(stack.pop(), new IntNode(2));
         assertEquals(stack.pop(), new IntNode(1));
@@ -84,6 +90,8 @@ public class WFIStackTest
         stack.push(new IntNode(1));
         assertEquals(stack.pop(), new IntNode(1));
         assertNull(stack.pop());
+        assertTrue(stack.isEmpty());
+        assertEquals(stack.size(), 0);
     }
 
     @Test


### PR DESCRIPTION
The WFIStack is added to the set of experimental data structures.
This data structure has, from experience, proven useful for implementing a number of other concurrency primitives.

Let me know if this is interesting.