### PR TITLE
Fixed versions in pom

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ And setup the following dependency:
         </dependency>
 ```
 
-You can also depend on latest snapshot from this repository (live on the edge) by setting the version to '3.0.1-SNAPSHOT'.
+You can also depend on latest snapshot from this repository (live on the edge) by setting the version to '3.1.1-SNAPSHOT'.
 
 
 Build it from source

--- a/jctools-benchmarks/pom.xml
+++ b/jctools-benchmarks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jctools-benchmarks</artifactId>

--- a/jctools-build/pom.xml
+++ b/jctools-build/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>jctools-build</artifactId>
     <name>JCTools Build Tools</name>

--- a/jctools-channels/pom.xml
+++ b/jctools-channels/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jctools-channels</artifactId>

--- a/jctools-concurrency-test/pom.xml
+++ b/jctools-concurrency-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jctools-concurrency-test</artifactId>

--- a/jctools-core/pom.xml
+++ b/jctools-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jctools</groupId>
 		<artifactId>jctools-parent</artifactId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jctools-core</artifactId>

--- a/jctools-experimental/pom.xml
+++ b/jctools-experimental/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jctools-experimental</artifactId>


### PR DESCRIPTION
The version of jctools is 3.1.1-SNAPSHOT.

But some some of the poms were pointing to 3.0.1-SNAPSHOT.

I was not able to build to project without getting this fixed.