### PR TITLE
Update to JCStress 0.7 and fix tests for updated APIs

### DIFF
--- a/jctools-concurrency-test/pom.xml
+++ b/jctools-concurrency-test/pom.xml
@@ -12,7 +12,7 @@
     <name>concurrency-test</name>
 
     <properties>
-        <jcstress.version>0.2</jcstress.version>
+        <jcstress.version>0.7</jcstress.version>
     </properties>
 
     <dependencies>

--- a/jctools-concurrency-test/src/main/java/org/jctools/queues/SpscArrayQueueConsumerTest.java
+++ b/jctools-concurrency-test/src/main/java/org/jctools/queues/SpscArrayQueueConsumerTest.java
@@ -5,7 +5,7 @@ import org.openjdk.jcstress.annotations.Arbiter;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
-import org.openjdk.jcstress.infra.results.IntResult1;
+import org.openjdk.jcstress.infra.results.I_Result;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
@@ -29,7 +29,7 @@ public class SpscArrayQueueConsumerTest {
     }
 
     @Arbiter
-    public void arbiter1(IntResult1 result) {
-        result.r1 = queue.size();
+    public void arbiter(I_Result r) {
+        r.r1 = queue.size();
     }
 }

--- a/jctools-concurrency-test/src/main/java/org/jctools/queues/SpscArrayQueueProducerConsumerTest.java
+++ b/jctools-concurrency-test/src/main/java/org/jctools/queues/SpscArrayQueueProducerConsumerTest.java
@@ -5,7 +5,7 @@ import org.openjdk.jcstress.annotations.Arbiter;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
-import org.openjdk.jcstress.infra.results.IntResult1;
+import org.openjdk.jcstress.infra.results.I_Result;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
@@ -32,7 +32,7 @@ public class SpscArrayQueueProducerConsumerTest {
     }
 
     @Arbiter
-    public void arbiter1(IntResult1 result) {
-        result.r1 = queue.size();
+    public void arbiter(I_Result r) {
+        r.r1 = queue.size();
     }
 }

--- a/jctools-concurrency-test/src/main/java/org/jctools/queues/SpscArrayQueueProducerTest.java
+++ b/jctools-concurrency-test/src/main/java/org/jctools/queues/SpscArrayQueueProducerTest.java
@@ -5,7 +5,7 @@ import org.openjdk.jcstress.annotations.Arbiter;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
-import org.openjdk.jcstress.infra.results.BooleanResult2;
+import org.openjdk.jcstress.infra.results.ZZ_Result;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE_INTERESTING;
@@ -21,12 +21,12 @@ public class SpscArrayQueueProducerTest {
     private final SpscArrayQueue<Integer> queue = new SpscArrayQueue<>(3);
 
     @Actor
-    public void actor1(BooleanResult2 br2) {
-        br2.r1 = queue.offer(1);
+    public void actor1(ZZ_Result r) {
+        r.r1 = queue.offer(1);
     }
 
     @Arbiter
-    public void arbiter1(BooleanResult2 br2) {
-        br2.r2 = !queue.isEmpty();
+    public void arbiter1(ZZ_Result r) {
+        r.r2 = !queue.isEmpty();
     }
 }

--- a/jctools-concurrency-test/src/main/java/org/jctools/sets/SingleWriterHashSetDuplicateReadsTest.java
+++ b/jctools-concurrency-test/src/main/java/org/jctools/sets/SingleWriterHashSetDuplicateReadsTest.java
@@ -4,7 +4,7 @@ import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
-import org.openjdk.jcstress.infra.results.IntResult1;
+import org.openjdk.jcstress.infra.results.I_Result;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
@@ -35,7 +35,7 @@ public class SingleWriterHashSetDuplicateReadsTest {
     }
 
     @Actor
-    public void actor2(IntResult1 result) {
+    public void actor2(I_Result r) {
         int counter = 0;
         for (Integer integer : set) {
             if (integer == 17) {
@@ -43,6 +43,6 @@ public class SingleWriterHashSetDuplicateReadsTest {
             }
         }
 
-        result.r1 = counter;
+        r.r1 = counter;
     }
 }

--- a/jctools-concurrency-test/src/main/java/org/jctools/sets/SingleWriterHashSetRemovalTest.java
+++ b/jctools-concurrency-test/src/main/java/org/jctools/sets/SingleWriterHashSetRemovalTest.java
@@ -4,7 +4,7 @@ import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
-import org.openjdk.jcstress.infra.results.BooleanResult1;
+import org.openjdk.jcstress.infra.results.Z_Result;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
@@ -33,7 +33,7 @@ public class SingleWriterHashSetRemovalTest {
     }
 
     @Actor
-    public void actor2(BooleanResult1 result) {
-        result.r1 = set.contains(17);
+    public void actor2(Z_Result r) {
+        r.r1 = set.contains(17);
     }
 }


### PR DESCRIPTION
JCTools use the ancient JCStress 0.2. Let's use a much more modern 0.7.

Testing:
  - [x] `mvn clean install -pl jctools-concurrency-test`
  - [x] `java -jar jctools-concurrency-test/target/concurrency-test.jar` (`SingleWriterHashSetDuplicateReadsTest` still fails, as it should?).