### PR TITLE
Linearizability tests for concurrent maps and sets

### DIFF
--- a/jctools-core/pom.xml
+++ b/jctools-core/pom.xml
@@ -33,7 +33,24 @@
 			<version>${guava-testlib.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>lincheck</artifactId>
+			<version>${lincheck.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
+
+	<repositories>
+		<repository>
+			<!-- Source for org.jetbrains.kotlinx.lincheck -->
+			<id>bintray-kotlin-kotlinx</id>
+			<name>kotlin-kotlinx</name>
+			<url>https://kotlin.bintray.com/kotlinx</url>
+		</repository>
+	</repositories>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/jctools-core/src/test/java/org/jctools/maps/NBHMIdentityKeyAtomicityTest.java
+++ b/jctools-core/src/test/java/org/jctools/maps/NBHMIdentityKeyAtomicityTest.java
@@ -1,0 +1,103 @@
+package org.jctools.maps;
+
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+
+public class NBHMIdentityKeyAtomicityTest
+{
+    static final int THREAD_SEGMENT = 1000000;
+
+    @Test
+    public void putReturnValuesAreDistinct() throws Exception
+    {
+        Map<String, Long> map = new NonBlockingIdentityHashMap<>();
+        map.put("K", -1l);
+        int processors = Runtime.getRuntime().availableProcessors();
+        CountDownLatch ready = new CountDownLatch(processors);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(processors);
+        AtomicBoolean keepRunning = new AtomicBoolean(true);
+        PutKey[] putKeys = new PutKey[processors];
+        for (int i = 0; i < processors; i++)
+        {
+            putKeys[i] = new PutKey(map, "K", keepRunning, ready, start, done, i * THREAD_SEGMENT);
+            Thread t = new Thread(putKeys[i]);
+            t.setName("Putty McPutkey-"+i);
+            t.start();
+        }
+        ready.await();
+        start.countDown();
+        Thread.sleep(1000);
+        keepRunning.set(false);
+        done.await();
+        Set<Long> values = new HashSet((int)(processors*THREAD_SEGMENT));
+        long totalKeys = 0;
+        for (PutKey putKey : putKeys)
+        {
+            values.addAll(putKey.values);
+            totalKeys += putKey.endIndex - putKey.startIndex;
+        }
+        assertEquals(totalKeys, values.size());
+    }
+
+    static class PutKey implements Runnable
+    {
+        final Map<String, Long> map;
+        final String key;
+        final AtomicBoolean keepRunning;
+        final CountDownLatch ready;
+        final CountDownLatch start;
+        final CountDownLatch done;
+        final int startIndex;
+        int endIndex;
+
+        List<Long> values = new ArrayList<>(THREAD_SEGMENT);
+
+        PutKey(
+            Map<String, Long> map,
+            String key,
+            AtomicBoolean keepRunning, CountDownLatch ready,
+            CountDownLatch start,
+            CountDownLatch done,
+            int startIndex)
+        {
+            this.map = map;
+            this.key = key;
+            this.keepRunning = keepRunning;
+            this.ready = ready;
+            this.start = start;
+            this.done = done;
+            this.startIndex = startIndex;
+            assert startIndex >= 0 && startIndex + THREAD_SEGMENT > 0;
+        }
+
+        @Override
+        public void run()
+        {
+            ready.countDown();
+            try
+            {
+                start.await();
+            }
+            catch (InterruptedException e)
+            {
+                e.printStackTrace();
+                return;
+            }
+            long limit = startIndex + THREAD_SEGMENT;
+            long v = startIndex;
+            String k = key;
+            for (; v < limit && keepRunning.get(); v++)
+            {
+                values.add(map.put(k, v));
+            }
+            endIndex = (int) v;
+            done.countDown();
+        }
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/maps/NBHMLongKeyAtomicityTest.java
+++ b/jctools-core/src/test/java/org/jctools/maps/NBHMLongKeyAtomicityTest.java
@@ -1,0 +1,103 @@
+package org.jctools.maps;
+
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+
+public class NBHMLongKeyAtomicityTest
+{
+    static final int THREAD_SEGMENT = 1000000;
+    static final long K = 1;
+    @Test
+    public void putReturnValuesAreDistinct() throws Exception
+    {
+        Map<Long, Long> map = new NonBlockingHashMapLong<>();
+        map.put(K, -1l);
+        int processors = Runtime.getRuntime().availableProcessors();
+        CountDownLatch ready = new CountDownLatch(processors);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(processors);
+        AtomicBoolean keepRunning = new AtomicBoolean(true);
+        PutKey[] putKeys = new PutKey[processors];
+        for (int i = 0; i < processors; i++)
+        {
+            putKeys[i] = new PutKey(map, K, keepRunning, ready, start, done, i * THREAD_SEGMENT);
+            Thread t = new Thread(putKeys[i]);
+            t.setName("Putty McPutkey-"+i);
+            t.start();
+        }
+        ready.await();
+        start.countDown();
+        Thread.sleep(1000);
+        keepRunning.set(false);
+        done.await();
+        Set<Long> values = new HashSet((int)(processors*THREAD_SEGMENT));
+        long totalKeys = 0;
+        for (PutKey putKey : putKeys)
+        {
+            values.addAll(putKey.values);
+            totalKeys += putKey.endIndex - putKey.startIndex;
+        }
+        assertEquals(totalKeys, values.size());
+    }
+
+    static class PutKey implements Runnable
+    {
+        final Map<Long, Long> map;
+        final long key;
+        final AtomicBoolean keepRunning;
+        final CountDownLatch ready;
+        final CountDownLatch start;
+        final CountDownLatch done;
+        final int startIndex;
+        int endIndex;
+
+        List<Long> values = new ArrayList<>(THREAD_SEGMENT);
+
+        PutKey(
+            Map<Long, Long> map,
+            long key,
+            AtomicBoolean keepRunning, CountDownLatch ready,
+            CountDownLatch start,
+            CountDownLatch done,
+            int startIndex)
+        {
+            this.map = map;
+            this.key = key;
+            this.keepRunning = keepRunning;
+            this.ready = ready;
+            this.start = start;
+            this.done = done;
+            this.startIndex = startIndex;
+            assert startIndex >= 0 && startIndex + THREAD_SEGMENT > 0;
+        }
+
+        @Override
+        public void run()
+        {
+            ready.countDown();
+            try
+            {
+                start.await();
+            }
+            catch (InterruptedException e)
+            {
+                e.printStackTrace();
+                return;
+            }
+            long limit = startIndex + THREAD_SEGMENT;
+            long v = startIndex;
+            long k = key;
+            for (; v < limit && keepRunning.get(); v++)
+            {
+                values.add(map.put(k, v));
+            }
+            endIndex = (int) v;
+            done.countDown();
+        }
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/maps/linearizability_test/LincheckMapTest.java
+++ b/jctools-core/src/test/java/org/jctools/maps/linearizability_test/LincheckMapTest.java
@@ -1,0 +1,109 @@
+package org.jctools.maps.linearizability_test;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.kotlinx.lincheck.*;
+import org.jetbrains.kotlinx.lincheck.annotations.*;
+import org.jetbrains.kotlinx.lincheck.paramgen.*;
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions;
+import org.jetbrains.kotlinx.lincheck.strategy.stress.StressOptions;
+import org.jetbrains.kotlinx.lincheck.verifier.VerifierState;
+import org.junit.Test;
+
+import java.util.Map;
+
+@Param(name = "key", gen = LongGen.class, conf = "1:5") // keys are longs in 1..5 range
+@Param(name = "value", gen = IntGen.class, conf = "1:10") // values are longs in 1..10 range
+public abstract class LincheckMapTest extends VerifierState
+{
+    private final Map<Long, Integer> map;
+
+    public LincheckMapTest(Map<Long, Integer> map)
+    {
+        this.map = map;
+    }
+
+    @Operation
+    public Integer get(@Param(name = "key") long key)
+    {
+        return map.get(key);
+    }
+
+    @Operation
+    public Integer put(@Param(name = "key") long key, @Param(name = "value") int value)
+    {
+        return map.put(key, value);
+    }
+
+    @Operation
+    public boolean replace(@Param(name = "key") long key, @Param(name = "value") int previousValue, @Param(name = "value") int nextValue)
+    {
+        return map.replace(key, previousValue, nextValue);
+    }
+
+    @Operation
+    public Integer remove(@Param(name = "key") long key)
+    {
+        return map.remove(key);
+    }
+
+    @Operation
+    public boolean containsKey(@Param(name = "key") long key)
+    {
+        return map.containsKey(key);
+    }
+
+    @Operation
+    public boolean containsValue(@Param(name = "value") int value)
+    {
+        return map.containsValue(value);
+    }
+
+    @Operation
+    public void clear()
+    {
+        map.clear();
+    }
+
+    /**
+     * This test checks that the concurrent map is linearizable with bounded model checking.
+     * Unlike stress testing, this approach can also provide a trace of an incorrect execution.
+     * However, it uses sequential consistency model, so it can not find any low-level bugs (e.g., missing 'volatile'),
+     * and thus, it it recommended to have both test modes.
+     */
+    @Test
+    public void modelCheckingTest()
+    {
+        ModelCheckingOptions options = new ModelCheckingOptions();
+        // The size of the test can be changed with 'options.iterations' or `options.invocationsPerIteration`.
+        // The first one defines the number of different scenarios generated,
+        // while the second one determines how deeply each scenario is tested.
+        new LinChecker(this.getClass(), options).check();
+    }
+
+    /**
+     * This test checks that the concurrent map is linearizable with stress testing.
+     */
+    @Test
+    public void stressTest()
+    {
+        StressOptions options = new StressOptions();
+        // The size of the test can be changed with 'options.iterations' or `options.invocationsPerIteration`.
+        // The first one defines the number of different scenarios generated,
+        // while the second one determines how deeply each scenario is tested.
+        new LinChecker(this.getClass(), options).check();
+    }
+
+    /**
+     * Provides something with correct <tt>equals</tt> and <tt>hashCode</tt> methods
+     * that can be interpreted as an internal data structure state for faster verification.
+     * The only limitation is that it should be different for different data structure states.
+     * For {@link Map} it itself is used.
+     * @return object representing internal state
+     */
+    @NotNull
+    @Override
+    protected Object extractState()
+    {
+        return map;
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/maps/linearizability_test/LincheckSetTest.java
+++ b/jctools-core/src/test/java/org/jctools/maps/linearizability_test/LincheckSetTest.java
@@ -1,0 +1,90 @@
+package org.jctools.maps.linearizability_test;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.kotlinx.lincheck.*;
+import org.jetbrains.kotlinx.lincheck.annotations.*;
+import org.jetbrains.kotlinx.lincheck.paramgen.*;
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions;
+import org.jetbrains.kotlinx.lincheck.strategy.stress.StressOptions;
+import org.jetbrains.kotlinx.lincheck.verifier.VerifierState;
+import org.junit.Test;
+
+import java.util.Set;
+
+@Param(name = "key", gen = IntGen.class, conf = "1:5") // keys are longs in 1..5 range
+public abstract class LincheckSetTest extends VerifierState
+{
+    private final Set<Integer> set;
+
+    public LincheckSetTest(Set<Integer> set)
+    {
+        this.set = set;
+    }
+
+    @Operation
+    public boolean contains(@Param(name = "key") int key)
+    {
+        return set.contains(key);
+    }
+
+    @Operation
+    public boolean add(@Param(name = "key") int key)
+    {
+        return set.add(key);
+    }
+
+    @Operation
+    public boolean remove(@Param(name = "key") int key)
+    {
+        return set.remove(key);
+    }
+
+    @Operation
+    public void clear()
+    {
+        set.clear();
+    }
+
+    /**
+     * This test checks that the concurrent set is linearizable with bounded model checking.
+     * Unlike stress testing, this approach can also provide a trace of an incorrect execution.
+     * However, it uses sequential consistency model, so it can not find any low-level bugs (e.g., missing 'volatile'),
+     * and thus, it it recommended to have both test modes.
+     */
+    @Test
+    public void modelCheckingTest()
+    {
+        ModelCheckingOptions options = new ModelCheckingOptions();
+        // The size of the test can be changed with 'options.iterations' or `options.invocationsPerIteration`.
+        // The first one defines the number of different scenarios generated,
+        // while the second one determines how deeply each scenario is tested.
+        new LinChecker(this.getClass(), options).check();
+    }
+
+    /**
+     * This test checks that the concurrent set is linearizable with stress testing.
+     */
+    @Test
+    public void stressTest()
+    {
+        StressOptions options = new StressOptions();
+        // The size of the test can be changed with 'options.iterations' or `options.invocationsPerIteration`.
+        // The first one defines the number of different scenarios generated,
+        // while the second one determines how deeply each scenario is tested.
+        new LinChecker(this.getClass(), options).check();
+    }
+
+    /**
+     * Provides something with correct <tt>equals</tt> and <tt>hashCode</tt> methods
+     * that can be interpreted as an internal data structure state for faster verification.
+     * The only limitation is that it should be different for different data structure states.
+     * For {@link Set} it itself is used.
+     * @return object representing internal state
+     */
+    @NotNull
+    @Override
+    protected Object extractState()
+    {
+        return set;
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/maps/linearizability_test/NonBlockingHashMapLinearizabilityTest.java
+++ b/jctools-core/src/test/java/org/jctools/maps/linearizability_test/NonBlockingHashMapLinearizabilityTest.java
@@ -1,0 +1,11 @@
+package org.jctools.maps.linearizability_test;
+
+import org.jctools.maps.NonBlockingHashMap;
+
+public class NonBlockingHashMapLinearizabilityTest extends LincheckMapTest
+{
+    public NonBlockingHashMapLinearizabilityTest()
+    {
+        super(new NonBlockingHashMap<>());
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/maps/linearizability_test/NonBlockingHashMapLongLinearizabilityTest.java
+++ b/jctools-core/src/test/java/org/jctools/maps/linearizability_test/NonBlockingHashMapLongLinearizabilityTest.java
@@ -1,0 +1,11 @@
+package org.jctools.maps.linearizability_test;
+
+import org.jctools.maps.NonBlockingHashMapLong;
+
+public class NonBlockingHashMapLongLinearizabilityTest extends LincheckMapTest
+{
+    public NonBlockingHashMapLongLinearizabilityTest()
+    {
+        super(new NonBlockingHashMapLong<>());
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/maps/linearizability_test/NonBlockingHashSetLinearizabilityTest.java
+++ b/jctools-core/src/test/java/org/jctools/maps/linearizability_test/NonBlockingHashSetLinearizabilityTest.java
@@ -1,0 +1,11 @@
+package org.jctools.maps.linearizability_test;
+
+import org.jctools.maps.NonBlockingHashSet;
+
+public class NonBlockingHashSetLinearizabilityTest extends LincheckSetTest
+{
+    public NonBlockingHashSetLinearizabilityTest()
+    {
+        super(new NonBlockingHashSet<>());
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/maps/linearizability_test/NonBlockingIdentityHashMapLinearizabilityTest.java
+++ b/jctools-core/src/test/java/org/jctools/maps/linearizability_test/NonBlockingIdentityHashMapLinearizabilityTest.java
@@ -1,0 +1,15 @@
+package org.jctools.maps.linearizability_test;
+
+import org.jctools.maps.NonBlockingIdentityHashMap;
+
+public class NonBlockingIdentityHashMapLinearizabilityTest extends LincheckMapTest
+{
+    public NonBlockingIdentityHashMapLinearizabilityTest()
+    {
+        // For NonBlockingIdentityHashMap operations with long keys may seem strange,
+        // but as small Longs are typically cached in the jvm,
+        // map.put(1L, value); map.containsKey(1L);
+        // returns true, not false.
+        super(new NonBlockingIdentityHashMap<>());
+    }
+}

--- a/jctools-core/src/test/java/org/jctools/maps/linearizability_test/NonBlockingSetIntLinearizabilityTest.java
+++ b/jctools-core/src/test/java/org/jctools/maps/linearizability_test/NonBlockingSetIntLinearizabilityTest.java
@@ -1,0 +1,11 @@
+package org.jctools.maps.linearizability_test;
+
+import org.jctools.maps.NonBlockingSetInt;
+
+public class NonBlockingSetIntLinearizabilityTest extends LincheckSetTest
+{
+    public NonBlockingSetIntLinearizabilityTest()
+    {
+        super(new NonBlockingSetInt());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>4.12</junit.version>
         <guava-testlib.version>21.0</guava-testlib.version>
+        <lincheck.version>2.9</lincheck.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request adds linearizability tests for concurrent maps and sets, based on [Lincheck](https://github.com/Kotlin/kotlinx-lincheck).
Lincheck tests are written in a declarative style, for which you need only to declare possible concurrent operations in the data structure - Lincheck will generate concurrent scenarios, run them, and verify their results automatically.

The tests help to reproduce the bug in #319 with a trace available for an incorrect execution.

They also expose another bug that `NonBlockingIdentityHashMap.replace` fails if there were no such key before.
For example, `new NonBlockingIdentityHashMap().replace(1, 0);` will throw an `AssertionError`, because of unexpected `null` value. I have a strong feeling that a `TOMBSTONE` should have been there instead.

I also found that a `size` method is not linearizable when a concurrent `put` operation is in action. But I think that it is a feature rather than a bug, because _efficient and linearizable_ `size` operation is often difficult to implement, although I haven't found any note in the documentation about the problem.