### PR TITLE
Build Multi-Release Jar

### DIFF
--- a/jctools-core/pom.xml
+++ b/jctools-core/pom.xml
@@ -55,6 +55,26 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<executions>
+					<execution>
+						<id>compile-java11</id>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<release>${java.multi-release.version}</release>
+							<compileSourceRoots>
+								<compileSourceRoot>${project.basedir}/src/main/java${java.multi-release.version}</compileSourceRoot>
+							</compileSourceRoots>
+							<multiReleaseOutput>true</multiReleaseOutput>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.0.0-M3</version>
 				<configuration>
@@ -66,11 +86,12 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>4.2.1</version>
+				<version>5.1.2</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
 						<Import-Package>sun.misc;resolution:=optional</Import-Package>
+						<Export-Package>org.jctools.*</Export-Package>
 					</instructions>
 				</configuration>
 			</plugin>
@@ -122,6 +143,7 @@
 					<archive>
 						<manifestEntries>
 							<Automatic-Module-Name>org.jctools.core</Automatic-Module-Name>
+							<Multi-Release>true</Multi-Release>
 						</manifestEntries>
 					</archive>
 				</configuration>

--- a/jctools-core/src/main/java11/module-info.java
+++ b/jctools-core/src/main/java11/module-info.java
@@ -1,0 +1,6 @@
+module org.jctools.core {
+    exports org.jctools.counters;
+    exports org.jctools.maps;
+    exports org.jctools.queues;
+    exports org.jctools.util;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.6</java.version>
         <java.test.version>1.8</java.test.version>
+        <java.multi-release.version>11</java.multi-release.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -98,7 +99,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>${java.test.version}</version>
+                                    <version>${java.multi-release.version}</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Builds a multi-release JAR which enables using features from newer JDK versions while still supporting Java 6. For example, any of the following can be done:
* Implementing #284 in a clean fashion without any need for reflection or static initializers
* Switching to VarHandles instead of Unsafe, or if Unsafe is considered better for performance reasons, adding some sort of fallback to VarHandles in case Unsafe is not available
* Adding a full `module-info` which adds support for jlink.

### Module-Info
This PR also adds `module-info` to the JDK 11 source set - mainly as an example and first step in what can be accomplished with a MR JAR. This is designed first and foremost to create a multi-release jar so that JCTools can leverage features from new JDK versions.

### Compatibility - OSGI and Others
I made sure to maintain the same OSGI information in the manifest. The felix plugin originally thought that META-INF/versions/11 was a package, but that has been fixed. There is still a minor warning because bnd does not think there should be classes inside META-INF/versions/11. It all still works beside that and [OSGI supports MR JARs](https://blog.osgi.org/2018/02/osgi-r7-highlights-java-9-support.html) just fine. Also relevant is https://github.com/bndtools/bnd/issues/2227

Besides OSGI, there were a couple webservers which had incompatibilities with module-info.class being placed inside the root of the jar. To address that, most projects add module-info inside META-INF/versions rather than the jar root (which this PR also does). Plenty of popular libraries have done something like this by now so I do not envision an issue for JCTools either.