### PR TITLE
Update to JCStress 0.9

### DIFF
--- a/jctools-concurrency-test/pom.xml
+++ b/jctools-concurrency-test/pom.xml
@@ -12,7 +12,7 @@
     <name>concurrency-test</name>
 
     <properties>
-        <jcstress.version>0.7</jcstress.version>
+        <jcstress.version>0.9</jcstress.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
JCStress 0.8 and 0.9 comes with a few goodies that should be useful for concurrency testing: split compilation and actor affinity. This picks up 0.9.

Testing:
 - [x] `mvn clean install -pl jctools-concurrency-test`
 - [x] `java -jar jctools-concurrency-test/target/concurrency-test.jar` (`SingleWriterHashSetDuplicateReadsTest` still fails, as it should?).