### PR TITLE
Fix broken artifact repository and update Lincheck to 2.14.1

### DIFF
--- a/jctools-core/pom.xml
+++ b/jctools-core/pom.xml
@@ -36,20 +36,11 @@
 
 		<dependency>
 			<groupId>org.jetbrains.kotlinx</groupId>
-			<artifactId>lincheck</artifactId>
+			<artifactId>lincheck-jvm</artifactId>
 			<version>${lincheck.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
-	<repositories>
-		<repository>
-			<!-- Source for org.jetbrains.kotlinx.lincheck -->
-			<id>bintray-kotlin-kotlinx</id>
-			<name>kotlin-kotlinx</name>
-			<url>https://kotlin.bintray.com/kotlinx</url>
-		</repository>
-	</repositories>
 
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>4.12</junit.version>
         <guava-testlib.version>21.0</guava-testlib.version>
-        <lincheck.version>2.9</lincheck.version>
+        <lincheck.version>2.14.1</lincheck.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
bintray.com artifact repository is no longer available.
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

So, instead, the maven central repository should be used with a new version 2.14.1, which has some bug fixes and more verbose bug trace.