### PR TITLE
Use the ImportDeclaration(String, boolean, boolean) constructor

### DIFF
--- a/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicArrayQueueGenerator.java
+++ b/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicArrayQueueGenerator.java
@@ -126,7 +126,7 @@ public final class JavaParsingAtomicArrayQueueGenerator extends JavaParsingAtomi
         cu.addImport(importDeclaration("java.util.concurrent.atomic.AtomicReferenceArray"));
         cu.addImport(importDeclaration("java.util.concurrent.atomic.AtomicLongArray"));
         cu.addImport(importDeclaration("org.jctools.queues.MessagePassingQueueUtil"));
-        cu.addImport(staticImportDeclaration("org.jctools.queues.atomic.AtomicQueueUtil.*"));
+        cu.addImport(staticImportDeclaration("org.jctools.queues.atomic.AtomicQueueUtil"));
     }
 
     /**

--- a/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicLinkedQueueGenerator.java
+++ b/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicLinkedQueueGenerator.java
@@ -174,7 +174,7 @@ public final class JavaParsingAtomicLinkedQueueGenerator extends JavaParsingAtom
         cu.addImport(importDeclaration("org.jctools.queues.MessagePassingQueueUtil"));
         cu.addImport(importDeclaration("org.jctools.queues.QueueProgressIndicators"));
         cu.addImport(importDeclaration("org.jctools.queues.IndexedQueueSizeUtil"));
-        cu.addImport(staticImportDeclaration("org.jctools.queues.atomic.AtomicQueueUtil.*"));
+        cu.addImport(staticImportDeclaration("org.jctools.queues.atomic.AtomicQueueUtil"));
     }
 
     /**

--- a/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicQueueGenerator.java
+++ b/jctools-build/src/main/java/org/jctools/queues/atomic/JavaParsingAtomicQueueGenerator.java
@@ -291,7 +291,7 @@ abstract class JavaParsingAtomicQueueGenerator extends VoidVisitorAdapter<Void> 
     }
 
     protected ImportDeclaration importDeclaration(String name) {
-        return new ImportDeclaration(new Name(name), false, false);
+        return new ImportDeclaration(name, false, false);
     }
 
     /**
@@ -327,7 +327,7 @@ abstract class JavaParsingAtomicQueueGenerator extends VoidVisitorAdapter<Void> 
     }
 
     ImportDeclaration staticImportDeclaration(String name) {
-        return new ImportDeclaration(new Name(name), true, false);
+        return new ImportDeclaration(name, true, true);
     }
 
 }


### PR DESCRIPTION
The ImportDeclaration(String, boolean, boolean) constructor properly parses the fully qualified name into a Name, whereas the Name(String) constructor only assigns the String to identifier and leaves the qualifier empty. ImportDeclaration instances where Name has an empty qualifier are filtered out in javaparser >= 3.15.0.

With this change, everything works like before with the currently required javaparser 3.14.16, but it works the same way with all subsequent versions until the latest 3.24.0.

This change modifies the least lines of code. Nevertheless, one could achieve similar result by directly using the CompilerUnit.addImport(String) for the non-static, non-asterisk imports, and CompilerUnit.addImport(String, true, true) for the static asterisk imports. In which case the importDeclaration and staticImportDeclaration methods could be just deleted.