### PR TITLE
Resolve null dereference warnings

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java
@@ -727,7 +727,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
 
     private void resize(long oldMask, E[] oldBuffer, long pIndex, E e, Supplier<E> s)
     {
-        assert (e != null && s == null) || (e == null || s != null);
+        assert (e != null && s == null) || (e == null && s != null);
         int newBufferLength = getNextBufferSize(oldBuffer);
         final E[] newBuffer;
         try
@@ -748,7 +748,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
         final long offsetInOld = modifiedCalcCircularRefElementOffset(pIndex, oldMask);
         final long offsetInNew = modifiedCalcCircularRefElementOffset(pIndex, newMask);
 
-        soRefElement(newBuffer, offsetInNew, e == null ? s.get() : e);// element in new array
+        soRefElement(newBuffer, offsetInNew, s != null ? s.get() : e);// element in new array
         soRefElement(oldBuffer, nextArrayOffset(oldMask), newBuffer);// buffer linked
 
         // ASSERT code

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/BaseMpscLinkedAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/BaseMpscLinkedAtomicArrayQueue.java
@@ -755,7 +755,7 @@ abstract class BaseMpscLinkedAtomicArrayQueue<E> extends BaseMpscLinkedAtomicArr
     }
 
     private void resize(long oldMask, AtomicReferenceArray<E> oldBuffer, long pIndex, E e, Supplier<E> s) {
-        assert (e != null && s == null) || (e == null || s != null);
+        assert (e != null && s == null) || (e == null && s != null);
         int newBufferLength = getNextBufferSize(oldBuffer);
         final AtomicReferenceArray<E> newBuffer;
         try {
@@ -771,7 +771,7 @@ abstract class BaseMpscLinkedAtomicArrayQueue<E> extends BaseMpscLinkedAtomicArr
         final int offsetInOld = modifiedCalcCircularRefElementOffset(pIndex, oldMask);
         final int offsetInNew = modifiedCalcCircularRefElementOffset(pIndex, newMask);
         // element in new array
-        soRefElement(newBuffer, offsetInNew, e == null ? s.get() : e);
+        soRefElement(newBuffer, offsetInNew, s != null ? s.get() : e);
         // buffer linked
         soRefElement(oldBuffer, nextArrayOffset(oldMask), newBuffer);
         // ASSERT code

--- a/jctools-experimental/src/main/java/org/jctools/queues/unpadded/BaseMpscLinkedUnpaddedArrayQueue.java
+++ b/jctools-experimental/src/main/java/org/jctools/queues/unpadded/BaseMpscLinkedUnpaddedArrayQueue.java
@@ -686,7 +686,7 @@ abstract class BaseMpscLinkedUnpaddedArrayQueue<E> extends BaseMpscLinkedUnpadde
 
     private void resize(long oldMask, E[] oldBuffer, long pIndex, E e, Supplier<E> s)
     {
-        assert (e != null && s == null) || (e == null || s != null);
+        assert (e != null && s == null) || (e == null && s != null);
         int newBufferLength = getNextBufferSize(oldBuffer);
         final E[] newBuffer;
         try
@@ -707,7 +707,7 @@ abstract class BaseMpscLinkedUnpaddedArrayQueue<E> extends BaseMpscLinkedUnpadde
         final long offsetInOld = modifiedCalcCircularRefElementOffset(pIndex, oldMask);
         final long offsetInNew = modifiedCalcCircularRefElementOffset(pIndex, newMask);
 
-        soRefElement(newBuffer, offsetInNew, e == null ? s.get() : e);// element in new array
+        soRefElement(newBuffer, offsetInNew, s != null ? s.get() : e);// element in new array
         soRefElement(oldBuffer, nextArrayOffset(oldMask), newBuffer);// buffer linked
 
         // ASSERT code


### PR DESCRIPTION
The warning is spurious but resolution seems reasonable

* https://lgtm.com/projects/g/JCTools/JCTools/snapshot/2c7ccd9a614c23e98493bfbd2428f9cd14baa2a4/files/jctools-experimental/src/main/java/org/jctools/queues/unpadded/BaseMpscLinkedUnpaddedArrayQueue.java?sort=name&dir=ASC&mode=heatmap#xf259fa0128f03aba:1
* https://lgtm.com/projects/g/JCTools/JCTools/snapshot/2c7ccd9a614c23e98493bfbd2428f9cd14baa2a4/files/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java?sort=name&dir=ASC&mode=heatmap#xf259fa0128f03aba:1

The analysis claims to use the assert at the beginning of the function
to infer `s` may be null.
Upon inspection it appears to tautology, I think from usage it was
intended to assert that there must be one null, and one not null
argument between `e` and `s`.