### PR TITLE
Fixes #367: generate a JPMS module descriptor

### DIFF
--- a/jctools-core/pom.xml
+++ b/jctools-core/pom.xml
@@ -13,6 +13,12 @@
 	<packaging>bundle</packaging>
 
 	<dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
@@ -104,13 +110,6 @@
 						</goals>
 					</execution>
 				</executions>
-				<configuration>
-					<archive>
-						<manifestEntries>
-							<Automatic-Module-Name>org.jctools.core</Automatic-Module-Name>
-						</manifestEntries>
-					</archive>
-				</configuration>
 			</plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/jctools-core/src/main/java/org/jctools/counters/package-info.java
+++ b/jctools-core/src/main/java/org/jctools/counters/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Export
+package org.jctools.counters;
+
+import org.osgi.annotation.bundle.Export;

--- a/jctools-core/src/main/java/org/jctools/maps/package-info.java
+++ b/jctools-core/src/main/java/org/jctools/maps/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Export
+package org.jctools.maps;
+
+import org.osgi.annotation.bundle.Export;

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/package-info.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Export
+package org.jctools.queues.atomic;
+
+import org.osgi.annotation.bundle.Export;

--- a/jctools-core/src/main/java/org/jctools/queues/package-info.java
+++ b/jctools-core/src/main/java/org/jctools/queues/package-info.java
@@ -95,4 +95,7 @@
  *
  * @author nitsanw
  */
+@Export
 package org.jctools.queues;
+
+import org.osgi.annotation.bundle.Export;

--- a/jctools-core/src/main/java/org/jctools/queues/unpadded/package-info.java
+++ b/jctools-core/src/main/java/org/jctools/queues/unpadded/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Export
+package org.jctools.queues.unpadded;
+
+import org.osgi.annotation.bundle.Export;

--- a/jctools-core/src/main/java/org/jctools/util/package-info.java
+++ b/jctools-core/src/main/java/org/jctools/util/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Export
+package org.jctools.util;
+
+import org.osgi.annotation.bundle.Export;

--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,13 @@
         <maven.compiler.testSource>${java.test.version}</maven.compiler.testSource>
         <maven.compiler.testTarget>${java.test.version}</maven.compiler.testTarget>
 
+        <bnd.version>6.3.1</bnd.version>
+        <bundle-plugin.version>5.1.8</bundle-plugin.version>
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>4.13.2</junit.version>
         <guava-testlib.version>31.1-jre</guava-testlib.version>
         <lincheck.version>2.14.1</lincheck.version>
+        <osgi.version>8.0.0</osgi.version>
     </properties>
 
     <modules>
@@ -71,6 +74,16 @@
         <module>jctools-concurrency-test</module>
         <module>jctools-build</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.annotation</artifactId>
+                <version>${osgi.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <pluginManagement>
@@ -164,7 +177,23 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.6</version>
+                <version>${bundle-plugin.version}</version>
+                <dependencies>
+                    <!-- Same version as `biz.aQute.bnd.annotation` -->
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bndlib</artifactId>
+                        <version>${bnd.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <instructions>
+                        <!-- Adds a module descriptor named as the OSGI bundle -->
+                        <_jpms-module-info>$[maven-symbolicname];access=0</_jpms-module-info>
+                        <!-- Exports only explicitly annotated packages -->
+                        <_exportcontents>$[packages;ANNOTATED;org.osgi.annotation.bundle.Export]</_exportcontents>
+                    </instructions>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Until now `jctools-core` used the Apache Felix Maven Bundle Plugin to generate its OSGI descriptor.

This PR:

* moves the internal classes to the `org.jctools.util.internal`. If needed this package can be exported to other JCTools artifacts using the `@ExportTo` annotation from BND.
* exports only explicitly annotated packages (i.e. all except `org.jctools.util.internal`). The OSGI descriptor becomes:
```
Export-Package: 
 org.jctools.queues.atomic;version="4.0.2";uses:="org.jctools.queues",
 org.jctools.queues.unpadded;version="4.0.2";uses:="org.jctools.queues",
 org.jctools.queues;version="4.0.2",
 org.jctools.maps;version="4.0.2",
 org.jctools.util;version="4.0.2",
 org.jctools.counters;version="4.0.2"
Import-Package: sun.misc;resolution:=optional
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
```
* automatically generates a `module-info.class` JPMS descriptor, which is in sync (cf. [JPMS libraries](https://bnd.bndtools.org/chapters/330-jpms.html)) with the OSGI descriptor:
```
module org.jctools.core@4.0.2.SNAPSHOT {
  requires java.base;
  requires static jdk.unsupported;
  exports org.jctools.queues;
  exports org.jctools.queues.atomic;
  exports org.jctools.queues.unpadded;
  exports org.jctools.maps;
  exports org.jctools.util;
  exports org.jctools.counters;
}
```
This descriptor can be generated by JDK 8.
