### PR TITLE
Update BaseMpscLinkedArrayQueue.java

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java
@@ -296,21 +296,14 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
 
         final long offset = modifiedCalcCircularRefElementOffset(cIndex, mask);
         Object e = lvRefElement(buffer, offset);
-        if (e == null)
+        while (e == null)
         {
-            long pIndex = lvProducerIndex();
-            // isEmpty?
-            if ((cIndex - pIndex) / 2 == 0)
-            {
-                return null;
-            }
-            // poll() == null iff queue is empty, null element is not strong enough indicator, so we must
-            // spin until element is visible.
-            do
+            if (cIndex != lvProducerIndex())
             {
                 e = lvRefElement(buffer, offset);
+                continue;
             }
-            while (e == null);
+            return null;
         }
 
         if (e == JUMP)


### PR DESCRIPTION
Let the poll method obtain data as soon as possible, and at the same time prevent the OOM problem that occurs after the resize method is started during the offer process, resulting in an infinite loop of the poll method.