### PR TITLE
Adding benchmark for thread-local object pool use case

### DIFF
--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/latency/QueueAsPoolBurstCost.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/latency/QueueAsPoolBurstCost.java
@@ -58,19 +58,19 @@ public class QueueAsPoolBurstCost {
       if (!noQ && warmup) {
          q = QueueByTypeFactory.createQueue(qType, 128);
 
-         final QueueBurstCost.Event event = new QueueBurstCost.Event();
+         final Object o = new Object();
 
          // stretch the queue to the limit, working through resizing and full
          // 128 * 2 account for the xadd qs that pool by default 2 chunks
          for (int i = 0; i < ((128 * 2) + 100); i++) {
-            q.offer(event);
+            q.offer(o);
          }
          for (int i = 0; i < ((128 * 2) + 100); i++) {
             q.poll();
          }
          // make sure the important common case is exercised
          for (int i = 0; i < 20000; i++) {
-            q.offer(event);
+            q.offer(o);
             q.poll();
          }
       }
@@ -112,8 +112,8 @@ public class QueueAsPoolBurstCost {
 
       @Setup
       public void init(QueueAsPoolBurstCost benchmark) {
-         acquired = new ArrayDeque<>(benchmark.burstSize);
-         pool = new ArrayDeque<>(benchmark.burstSize);
+         acquired = new ArrayDeque<Object>(benchmark.burstSize);
+         pool = new ArrayDeque<Object>(benchmark.burstSize);
          if ("None".equals(benchmark.qType)) {
             final Object o = new Object();
             for (int i = 0; i < benchmark.burstSize; i++) {

--- a/jctools-benchmarks/src/main/java/org/jctools/jmh/latency/QueueAsPoolBurstCost.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/jmh/latency/QueueAsPoolBurstCost.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.jmh.latency;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+
+import org.jctools.queues.QueueByTypeFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@SuppressWarnings("serial")
+public class QueueAsPoolBurstCost {
+
+   @Param({"None", "ArrayBlockingQueue", "ConcurrentLinkedQueue", "MpmcUnboundedXaddArrayQueue", "MpmcArrayQueue"})
+   String qType;
+   @Param({"1", "10"})
+   int burstSize;
+   @Param("true")
+   boolean warmup;
+   @Param(value = {"132000"})
+   String qCapacity;
+   Queue<Object> q;
+
+   @Setup
+   public void init() {
+      final boolean noQ = qType.equals("None");
+      if (!noQ && warmup) {
+         q = QueueByTypeFactory.createQueue(qType, 128);
+
+         final QueueBurstCost.Event event = new QueueBurstCost.Event();
+
+         // stretch the queue to the limit, working through resizing and full
+         // 128 * 2 account for the xadd qs that pool by default 2 chunks
+         for (int i = 0; i < ((128 * 2) + 100); i++) {
+            q.offer(event);
+         }
+         for (int i = 0; i < ((128 * 2) + 100); i++) {
+            q.poll();
+         }
+         // make sure the important common case is exercised
+         for (int i = 0; i < 20000; i++) {
+            q.offer(event);
+            q.poll();
+         }
+      }
+      q = noQ ? null : QueueByTypeFactory.buildQ(qType, qCapacity);
+      // fill the qs, if any
+      final Object o = new Object();
+      if (q != null) {
+         for (int i = 0; i < Integer.parseInt(qCapacity); i++) {
+            if (!q.offer(o)) {
+               throw new IllegalStateException("qCapacity isn't enough to hold all elements for " + qType);
+            }
+         }
+      }
+   }
+
+   @Benchmark
+   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+   public void acquireAndRelease(ThreadLocalPool tlPool) {
+      final int burst = burstSize;
+      final Queue<Object> pool = q == null ? tlPool.pool : q;
+      final ArrayDeque<Object> tmp = tlPool.acquired;
+      for (int i = 0; i < burst; i++) {
+         tmp.offer(pool.poll());
+      }
+      for (int i = 0; i < burst; i++) {
+         pool.offer(tmp.pollLast());
+      }
+   }
+
+   @State(Scope.Thread)
+   public static class ThreadLocalPool {
+
+      private ArrayDeque<Object> pool;
+      private ArrayDeque<Object> acquired;
+
+      @Setup
+      public void init(QueueAsPoolBurstCost benchmark) {
+         acquired = new ArrayDeque<>(benchmark.burstSize);
+         pool = new ArrayDeque<>(benchmark.burstSize);
+         if ("None".equals(benchmark.qType)) {
+            final Object o = new Object();
+            for (int i = 0; i < benchmark.burstSize; i++) {
+               pool.add(o);
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
This is a naive attempt to emulate a silly (but very soon quite frequent, [believe me](https://github.com/FasterXML/jackson-core/issues/919)) use case: object pooling without making the acquired object to escape the consumer thread.

This is a pattern very frequent in HFT, but not only: as mentioned before, with Virtual Thread(s) and Loom, we need alternatives to cover for the lack of per-carrier thread locals (see https://github.com/FasterXML/jackson-core/blob/390472bbdf4722fe058f48bb0eff5865c8d20f73/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclers.java#L36).

The recent answer from Heinz K. at https://mail.openjdk.org/pipermail/loom-dev/2023-February/005320.html 
made me ask; we suggest users to use our mpmc qs as object pool, but...they are the right/decent tools for the job?

With 3 threads:
```
Benchmark                               (burstSize)  (qCapacity)                      (qType)  (warmup)  Mode  Cnt     Score     Error  Units
QueueAsPoolBurstCost.acquireAndRelease            1       132000                         None      true  avgt   10    15.755 ±   0.309  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000           ArrayBlockingQueue      true  avgt   10   304.429 ±  14.945  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000        ConcurrentLinkedQueue      true  avgt   10   651.487 ±  27.480  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000  MpmcUnboundedXaddArrayQueue      true  avgt   10   404.714 ±   5.914  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000               MpmcArrayQueue      true  avgt   10   451.024 ±   7.468  ns/op
QueueAsPoolBurstCost.acquireAndRelease           10       132000                         None      true  avgt   10    82.535 ±   0.862  ns/op
QueueAsPoolBurstCost.acquireAndRelease           10       132000           ArrayBlockingQueue      true  avgt   10  2884.411 ± 417.531  ns/op
QueueAsPoolBurstCost.acquireAndRelease           10       132000        ConcurrentLinkedQueue      true  avgt   10  5856.916 ± 439.367  ns/op
QueueAsPoolBurstCost.acquireAndRelease           10       132000  MpmcUnboundedXaddArrayQueue      true  avgt   10  4304.779 ± 597.593  ns/op
QueueAsPoolBurstCost.acquireAndRelease           10       132000               MpmcArrayQueue      true  avgt   10  4395.881 ± 452.933  ns/op
```

I have introduced a fake CPU consume method (likely in the wrong place, given that's not emulating what real users will do - meaning we should add some before acquire as well, likely) and numbers, as usual appear slightly different:
```
Benchmark                               (burstSize)  (qCapacity)                      (qType)  (warmup)  (work)  Mode  Cnt     Score    Error  Units
QueueAsPoolBurstCost.acquireAndRelease            1       132000                         None      true       0  avgt   10    16.139 ±  0.182  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000                         None      true      10  avgt   10    30.127 ±  0.382  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000                         None      true     100  avgt   10   275.163 ±  1.003  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000           ArrayBlockingQueue      true       0  avgt   10   317.676 ± 11.457  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000           ArrayBlockingQueue      true      10  avgt   10   367.082 ± 16.133  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000           ArrayBlockingQueue      true     100  avgt   10  1180.306 ± 40.263  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000        ConcurrentLinkedQueue      true       0  avgt   10   664.938 ± 19.703  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000        ConcurrentLinkedQueue      true      10  avgt   10   620.152 ± 26.502  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000        ConcurrentLinkedQueue      true     100  avgt   10   653.506 ± 18.155  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000  MpmcUnboundedXaddArrayQueue      true       0  avgt   10   392.326 ±  9.412  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000  MpmcUnboundedXaddArrayQueue      true      10  avgt   10   397.462 ±  4.952  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000  MpmcUnboundedXaddArrayQueue      true     100  avgt   10   461.849 ± 23.687  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000               MpmcArrayQueue      true       0  avgt   10   455.009 ± 10.099  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000               MpmcArrayQueue      true      10  avgt   10   456.501 ± 14.344  ns/op
QueueAsPoolBurstCost.acquireAndRelease            1       132000               MpmcArrayQueue      true     100  avgt   10   483.445 ±  4.849  ns/op
```
Where "high" `work` now make the `ArrayBlockingQueue` a way less appealing solution (as expected? by me at least), but how much "high" translate into real-world "work" is not clear yet and makes me guess if our queues are good performer for this use case in realistic cases.

I'm aware that under very high contention lock-free queues aren't the best performer(s), but I wasn't expecting to happen with just 3 thread(s), meaning that I'm doing something wrong or not considering other factors.