### PR TITLE
#380: Expansion is successful, you can continue to get the element, OOM return null

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java
@@ -302,7 +302,33 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
             // isEmpty?
             if ((cIndex - pIndex) / 2 == 0)
             {
-                return null;
+                //resizing
+                if((pIndex & 1) == 1) {
+                    //resize fails(OOM) to roll back index values.
+                    //see resize:
+                    //assert lvProducerIndex() == pIndex + 1;
+                    //soProducerIndex(pIndex);
+                    //throw oom
+                    long rollbackIndex = pIndex-1;
+                    //spin:OOM return null;uccessfully resized break
+                    // otherwise spin
+                    //The number of spins should be small here, since this is in 
+                    // resizing and either OOM fails or succeeds
+                    while (true) {
+                        //OOM
+                        if (rollbackIndex == (pIndex = lvProducerIndex())) {
+                            return null;
+                        } else {
+                            if ((pIndex & 1) == 0) {
+                                //Successfully resized capacity
+                                break;
+                            }
+                        }
+                    }
+                }else {
+                    //cIndex==pIndex
+                    return null;
+                }
             }
             // poll() == null iff queue is empty, null element is not strong enough indicator, so we must
             // spin until element is visible.
@@ -345,7 +371,33 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
             // isEmpty?
             if ((cIndex - pIndex) / 2 == 0)
             {
-                return null;
+                //resizing
+                if((pIndex & 1) == 1) {
+                    //resize fails(OOM) to roll back index values.
+                    //see resize:
+                    //assert lvProducerIndex() == pIndex + 1;
+                    //soProducerIndex(pIndex);
+                    //throw oom
+                    long rollbackIndex = pIndex-1;
+                    //spin:OOM return null;uccessfully resized break
+                    // otherwise spin
+                    //The number of spins should be small here, since this is in 
+                    // resizing and either OOM fails or succeeds
+                    while (true) {
+                        //OOM
+                        if (rollbackIndex == (pIndex = lvProducerIndex())) {
+                            return null;
+                        } else {
+                            if ((pIndex & 1) == 0) {
+                                //Successfully resized capacity
+                                break;
+                            }
+                        }
+                    }
+                }else {
+                    //cIndex==pIndex
+                    return null;
+                }
             }
             // peek() == null iff queue is empty, null element is not strong enough indicator, so we must
             // spin until element is visible.


### PR DESCRIPTION
eg：Initial capacity is 2, index=0 has been filled, fill index=1 position, need to expand capacity, is expanding capacity, will pindex CAS to 0+1, at this time the consumer will be 0 position of the consumption of the poll to obtain 1 position of the element, cindex=2, at this time, e=null, if the expansion of capacity is successful, the oldbuffer cindex=2, at this time e=null, if the expansion is successful, the oldbuffer index=1 position will be filled with JUMP, the new buffer is filled with new elements. We just need to wait a moment to consume element.
But (cIndex - pIndex) / 2 == 0, it will return null directly, then cindex=2, pindex=1, this will soon have the element of the case is discarded。

So can we break the situation down a bit more?

cIndex-pIndex==0 , Empty
(pIndex & 1) == 1, resizing, further analysis:
① OOM occurs, pindex rolls back the current pIndex-1, so we keep pIndex-1, in the loop kind of judgment lvProducerIndex()==pIndex-1, if it is established, then OOM has occurred, return null
② normal expansion success, (pIndex & 1) == 0, break, continue later to get JUMP, get elements of the operation. Since ① has already filtered OOM, although it's also (pIndex & 1) == 0, do not worry about OOM here
if ((cIndex - pIndex) / 2 == 0)
            {
                //resizing
                if((pIndex & 1) == 1) {
                    //resize fails(OOM) to roll back index values.
                    //see resize:
                    //assert lvProducerIndex() == pIndex + 1;
                    //soProducerIndex(pIndex);
                    //throw oom
                    long rollbackIndex = pIndex-1;
                    while (true) {
                        //OOM
                        if (rollbackIndex == (pIndex = lvProducerIndex())) {
                            return null;
                        } else {
                            if ((pIndex & 1) == 0) {
                                //Successfully resized capacity
                                break;
                            }
                        }
                    }
                }else {
                    //cIndex==pIndex
                    return null;
                }
            }