### PR TITLE
fix: make producer index immedately visible to consumer

### DIFF
--- a/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/BaseMpscLinkedArrayQueue.java
@@ -67,6 +67,11 @@ abstract class BaseMpscLinkedArrayQueueProducerFields<E> extends BaseMpscLinkedA
         UNSAFE.putOrderedLong(this, P_INDEX_OFFSET, newValue);
     }
 
+    final void svProducerIndex(long newValue)
+    {
+        this.producerIndex = newValue;
+    }
+
     final boolean casProducerIndex(long expect, long newValue)
     {
         return UNSAFE.compareAndSwapLong(this, P_INDEX_OFFSET, expect, newValue);
@@ -760,8 +765,8 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
         // We never set the limit beyond the bounds of a buffer
         soProducerLimit(pIndex + Math.min(newMask, availableInQueue));
 
-        // make resize visible to the other producers
-        soProducerIndex(pIndex + 2);
+        // make resize visible to the other producers and immediately visible to consumer.
+        svProducerIndex(pIndex + 2);
 
         // INDEX visible before ELEMENT, consistent with consumer expectation
 

--- a/jctools-core/src/main/java/org/jctools/queues/MessagePassingQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MessagePassingQueue.java
@@ -107,7 +107,7 @@ public interface MessagePassingQueue<T>
      * according to the {@link Queue#offer(Object)} interface.
      *
      * @param e not {@code null}, will throw NPE if it is
-     * @return true if element was inserted into the queue, false iff full
+     * @return true if element was inserted into the queue, false if full or seen as full.
      */
     boolean offer(T e);
 

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/BaseMpscLinkedAtomicArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/BaseMpscLinkedAtomicArrayQueue.java
@@ -98,6 +98,10 @@ abstract class BaseMpscLinkedAtomicArrayQueueProducerFields<E> extends BaseMpscL
         P_INDEX_UPDATER.lazySet(this, newValue);
     }
 
+    final void svProducerIndex(long newValue) {
+        producerIndex = newValue;
+    }
+
     final boolean casProducerIndex(long expect, long newValue) {
         return P_INDEX_UPDATER.compareAndSet(this, expect, newValue);
     }
@@ -775,8 +779,8 @@ abstract class BaseMpscLinkedAtomicArrayQueue<E> extends BaseMpscLinkedAtomicArr
         // Invalidate racing CASs
         // We never set the limit beyond the bounds of a buffer
         soProducerLimit(pIndex + Math.min(newMask, availableInQueue));
-        // make resize visible to the other producers
-        soProducerIndex(pIndex + 2);
+        // make resize visible to the other producers and immediately visible to consumer.
+        svProducerIndex(pIndex + 2);
         // INDEX visible before ELEMENT, consistent with consumer expectation
         // make resize visible to consumer
         soRefElement(oldBuffer, offsetInOld, JUMP);

--- a/jctools-core/src/main/java/org/jctools/queues/atomic/unpadded/BaseMpscLinkedAtomicUnpaddedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/atomic/unpadded/BaseMpscLinkedAtomicUnpaddedArrayQueue.java
@@ -51,6 +51,10 @@ abstract class BaseMpscLinkedAtomicUnpaddedArrayQueueProducerFields<E> extends B
         P_INDEX_UPDATER.lazySet(this, newValue);
     }
 
+    final void svProducerIndex(long newValue) {
+        producerIndex = newValue;
+    }
+
     final boolean casProducerIndex(long expect, long newValue) {
         return P_INDEX_UPDATER.compareAndSet(this, expect, newValue);
     }
@@ -632,8 +636,8 @@ abstract class BaseMpscLinkedAtomicUnpaddedArrayQueue<E> extends BaseMpscLinkedA
         // Invalidate racing CASs
         // We never set the limit beyond the bounds of a buffer
         soProducerLimit(pIndex + Math.min(newMask, availableInQueue));
-        // make resize visible to the other producers
-        soProducerIndex(pIndex + 2);
+        // make resize visible to the other producers and immediately visible to consumer.
+        svProducerIndex(pIndex + 2);
         // INDEX visible before ELEMENT, consistent with consumer expectation
         // make resize visible to consumer
         soRefElement(oldBuffer, offsetInOld, JUMP);

--- a/jctools-core/src/main/java/org/jctools/queues/unpadded/BaseMpscLinkedUnpaddedArrayQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/unpadded/BaseMpscLinkedUnpaddedArrayQueue.java
@@ -53,6 +53,10 @@ abstract class BaseMpscLinkedUnpaddedArrayQueueProducerFields<E> extends BaseMps
         UNSAFE.putOrderedLong(this, P_INDEX_OFFSET, newValue);
     }
 
+    final void svProducerIndex(long newValue) {
+        this.producerIndex = newValue;
+    }
+
     final boolean casProducerIndex(long expect, long newValue) {
         return UNSAFE.compareAndSwapLong(this, P_INDEX_OFFSET, expect, newValue);
     }
@@ -630,8 +634,8 @@ abstract class BaseMpscLinkedUnpaddedArrayQueue<E> extends BaseMpscLinkedUnpadde
         // Invalidate racing CASs
         // We never set the limit beyond the bounds of a buffer
         soProducerLimit(pIndex + Math.min(newMask, availableInQueue));
-        // make resize visible to the other producers
-        soProducerIndex(pIndex + 2);
+        // make resize visible to the other producers and immediately visible to consumer.
+        svProducerIndex(pIndex + 2);
         // INDEX visible before ELEMENT, consistent with consumer expectation
         // make resize visible to consumer
         soRefElement(oldBuffer, offsetInOld, JUMP);


### PR DESCRIPTION
The contract is that if offer succeeds, then poll must see the offered object. Using soProducerIndex breaks such contract.