### PR TITLE
Introduce MpscBlockingQueue

### DIFF
--- a/jctools-benchmarks/src/main/java/org/jctools/queues/MpscBlockingQueueBenchmark.java
+++ b/jctools-benchmarks/src/main/java/org/jctools/queues/MpscBlockingQueueBenchmark.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmark for MpscBlockingQueue throughput with multiple producers
+ * and a single consumer. Tests both blocking and non-blocking variants.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+public class MpscBlockingQueueBenchmark
+{
+    private static final int NUM_PRODUCERS = 8;
+
+    @Param({"8", "64", "128", "512", "4096"})
+    public int queueCapacity;
+
+    private MpscBlockingQueue<Integer> queue;
+    private volatile int producerValue = 0;
+
+    @Setup(Level.Trial)
+    public void setup()
+    {
+        queue = new MpscBlockingQueue<>(queueCapacity);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown()
+    {
+        queue.clear();
+    }
+
+    @AuxCounters
+    @State(Scope.Thread)
+    public static class ProducerCounters
+    {
+        public long offersFailed = 0;
+        public long offersMade = 0;
+    }
+
+    @AuxCounters
+    @State(Scope.Thread)
+    public static class ConsumerCounters
+    {
+        public long pollsFailed = 0;
+        public long pollsMade = 0;
+    }
+
+    /**
+     * Non-blocking offer/poll benchmark.
+     */
+    @Benchmark
+    @Group("offerPoll")
+    @GroupThreads(NUM_PRODUCERS)
+    public void offerProducer(ProducerCounters counters)
+    {
+        if (queue.offer(producerValue++))
+        {
+            counters.offersMade++;
+        }
+        else
+        {
+            counters.offersFailed++;
+        }
+    }
+
+    @Benchmark
+    @Group("offerPoll")
+    @GroupThreads(1)
+    public void pollConsumer(ConsumerCounters counters)
+    {
+        Integer item = queue.poll();
+        if (item != null)
+        {
+            counters.pollsMade++;
+        }
+        else
+        {
+            counters.pollsFailed++;
+        }
+    }
+
+    /**
+     * Timed poll benchmark.
+     */
+    @Benchmark
+    @Group("timedPoll")
+    @GroupThreads(NUM_PRODUCERS)
+    public void offerProducerTimed(ProducerCounters counters)
+    {
+        if (queue.offer(producerValue++))
+        {
+            counters.offersMade++;
+        }
+        else
+        {
+            counters.offersFailed++;
+        }
+    }
+
+    @Benchmark
+    @Group("timedPoll")
+    @GroupThreads(1)
+    public void pollConsumerTimed(ConsumerCounters counters) throws InterruptedException
+    {
+        Integer item = queue.poll(100, TimeUnit.MILLISECONDS);
+        if (item != null)
+        {
+            counters.pollsMade++;
+        }
+        else
+        {
+            counters.pollsFailed++;
+        }
+    }
+
+    public static void main(String[] args) throws Exception
+    {
+        Options opt = new OptionsBuilder()
+            .include(MpscBlockingQueueBenchmark.class.getSimpleName())
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/MpscBlockingQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpscBlockingQueue.java
@@ -1,0 +1,389 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.queues;
+
+import static org.jctools.util.PortableJvmInfo.CPUs;
+import static org.jctools.util.Pow2.isPowerOfTwo;
+import static org.jctools.util.Pow2.roundToPowerOfTwo;
+
+import org.jctools.queues.MpscArrayQueue;
+import org.jctools.util.RangeUtil;
+
+import java.util.AbstractQueue;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+abstract class MpscBlockingQueueL0Pad<E> extends AbstractQueue<E>
+{
+    byte b000,b001,b002,b003,b004,b005,b006,b007;//  8b
+    byte b010,b011,b012,b013,b014,b015,b016,b017;// 16b
+    byte b020,b021,b022,b023,b024,b025,b026,b027;// 24b
+    byte b030,b031,b032,b033,b034,b035,b036,b037;// 32b
+    byte b040,b041,b042,b043,b044,b045,b046,b047;// 40b
+    byte b050,b051,b052,b053,b054,b055,b056,b057;// 48b
+    byte b060,b061,b062,b063,b064,b065,b066,b067;// 56b
+    byte b070,b071,b072,b073,b074,b075,b076,b077;// 64b
+    byte b100,b101,b102,b103,b104,b105,b106,b107;// 72b
+    byte b110,b111,b112,b113,b114,b115,b116,b117;// 80b
+    byte b120,b121,b122,b123,b124,b125,b126,b127;// 88b
+    byte b130,b131,b132,b133,b134,b135,b136,b137;// 96b
+    byte b140,b141,b142,b143,b144,b145,b146,b147;//104b
+    byte b150,b151,b152,b153,b154,b155,b156,b157;//112b
+    byte b160,b161,b162,b163,b164,b165,b166,b167;//120b
+    byte b170,b171,b172,b173,b174,b175,b176,b177;//128b
+}
+
+abstract class MpscBlockingQueueColdFields<E> extends MpscBlockingQueueL0Pad<E>
+{
+    protected final int parallelQueues;
+    protected final int parallelQueuesMask;
+    protected final MpscArrayQueue<E>[] queues;
+    protected final ConcurrentLinkedQueue<Thread>[] fullWaiters;
+
+    @SuppressWarnings("unchecked")
+    MpscBlockingQueueColdFields(int capacity, int queueParallelism)
+    {
+        parallelQueues = isPowerOfTwo(queueParallelism) ? queueParallelism
+                : roundToPowerOfTwo(queueParallelism) / 2;
+        parallelQueuesMask = parallelQueues - 1;
+        queues = new MpscArrayQueue[parallelQueues];
+        fullWaiters = new ConcurrentLinkedQueue[parallelQueues];
+        for (int i = 0; i < parallelQueues; i++)
+        {
+            fullWaiters[i] = new ConcurrentLinkedQueue<>();
+        }
+        int fullCapacity = roundToPowerOfTwo(capacity);
+        RangeUtil.checkGreaterThanOrEqual(fullCapacity, parallelQueues, "fullCapacity");
+        for (int i = 0; i < parallelQueues; i++)
+        {
+            queues[i] = new MpscArrayQueue<E>(fullCapacity);
+        }
+    }
+}
+
+abstract class MpscBlockingQueueMidPad<E> extends MpscBlockingQueueColdFields<E>
+{
+    byte b000,b001,b002,b003,b004,b005,b006,b007;//  8b
+    byte b010,b011,b012,b013,b014,b015,b016,b017;// 16b
+    byte b020,b021,b022,b023,b024,b025,b026,b027;// 24b
+    byte b030,b031,b032,b033,b034,b035,b036,b037;// 32b
+    byte b040,b041,b042,b043,b044,b045,b046,b047;// 40b
+    byte b050,b051,b052,b053,b054,b055,b056,b057;// 48b
+    byte b060,b061,b062,b063,b064,b065,b066,b067;// 56b
+    byte b070,b071,b072,b073,b074,b075,b076,b077;// 64b
+    byte b100,b101,b102,b103,b104,b105,b106,b107;// 72b
+    byte b110,b111,b112,b113,b114,b115,b116,b117;// 80b
+    byte b120,b121,b122,b123,b124,b125,b126,b127;// 88b
+    byte b130,b131,b132,b133,b134,b135,b136,b137;// 96b
+    byte b140,b141,b142,b143,b144,b145,b146,b147;//104b
+    byte b150,b151,b152,b153,b154,b155,b156,b157;//112b
+    byte b160,b161,b162,b163,b164,b165,b166,b167;//120b
+    byte b170,b171,b172,b173,b174,b175,b176,b177;//128b
+
+    MpscBlockingQueueMidPad(int capacity, int queueParallelism)
+    {
+        super(capacity, queueParallelism);
+    }
+}
+
+abstract class MpscBlockingQueueConsumerFields<E> extends MpscBlockingQueueMidPad<E>
+{
+    int consumerQueueIndex;
+    protected final ConcurrentLinkedQueue<Thread> emptyWaiters = new ConcurrentLinkedQueue<>();
+
+    MpscBlockingQueueConsumerFields(int capacity, int queueParallelism)
+    {
+        super(capacity, queueParallelism);
+    }
+}
+
+abstract class MpscBlockingQueueL2Pad<E> extends MpscBlockingQueueConsumerFields<E>
+{
+    byte b000,b001,b002,b003,b004,b005,b006,b007;//  8b
+    byte b010,b011,b012,b013,b014,b015,b016,b017;// 16b
+    byte b020,b021,b022,b023,b024,b025,b026,b027;// 24b
+    byte b030,b031,b032,b033,b034,b035,b036,b037;// 32b
+    byte b040,b041,b042,b043,b044,b045,b046,b047;// 40b
+    byte b050,b051,b052,b053,b054,b055,b056,b057;// 48b
+    byte b060,b061,b062,b063,b064,b065,b066,b067;// 56b
+    byte b070,b071,b072,b073,b074,b075,b076,b077;// 64b
+    byte b100,b101,b102,b103,b104,b105,b106,b107;// 72b
+    byte b110,b111,b112,b113,b114,b115,b116,b117;// 80b
+    byte b120,b121,b122,b123,b124,b125,b126,b127;// 88b
+    byte b130,b131,b132,b133,b134,b135,b136,b137;// 96b
+    byte b140,b141,b142,b143,b144,b145,b146,b147;//104b
+    byte b150,b151,b152,b153,b154,b155,b156,b157;//112b
+    byte b160,b161,b162,b163,b164,b165,b166,b167;//120b
+    byte b170,b171,b172,b173,b174,b175,b176,b177;//128b
+
+    MpscBlockingQueueL2Pad(int capacity, int queueParallelism)
+    {
+        super(capacity, queueParallelism);
+    }
+}
+
+/**
+ * A blocking MPSC queue implementation based on JCTools MpscArrayQueue.
+ * This queue uses multiple parallel queues to reduce contention among producers.
+ *
+ * @param <E> the type of elements held in this queue
+ */
+public class MpscBlockingQueue<E> extends MpscBlockingQueueL2Pad<E> implements BlockingQueue<E>
+{
+    private final AtomicInteger threadQueueIndexCounter = new AtomicInteger(0);
+    private final ThreadLocal<Integer> threadQueueIndex = new ThreadLocal<Integer>()
+    {
+        @Override
+        protected Integer initialValue()
+        {
+            return threadQueueIndexCounter.getAndIncrement() & parallelQueuesMask;
+        }
+    };
+
+    public MpscBlockingQueue(int capacity)
+    {
+        super(capacity, CPUs);
+    }
+
+    public MpscBlockingQueue(int capacity, int queueParallelism)
+    {
+        super(capacity, queueParallelism);
+    }
+
+
+    @Override
+    public E poll()
+    {
+        int qIndex = consumerQueueIndex & parallelQueuesMask;
+        final int limit = qIndex + parallelQueues;
+        E e = null;
+        for (; qIndex < limit; qIndex++)
+        {
+            final int id = qIndex & parallelQueuesMask;
+            e = queues[id].poll();
+            if (e != null)
+            {
+                unparkOneFullWaiter(id);
+                break;
+            }
+        }
+        consumerQueueIndex = qIndex;
+        return e;
+    }
+
+    @Override
+    public E peek()
+    {
+        int qIndex = consumerQueueIndex & parallelQueuesMask;
+        final int limit = qIndex + parallelQueues;
+        E e = null;
+        for (; qIndex < limit; qIndex++)
+        {
+            e = queues[qIndex & parallelQueuesMask].peek();
+            if (e != null)
+            {
+                break;
+            }
+        }
+        consumerQueueIndex = qIndex;
+        return e;
+    }
+
+    @Override
+    public int size()
+    {
+        int size = 0;
+        for (int i = 0; i < queues.length; i++)
+        {
+            size += queues[i].size();
+        }
+        return size;
+    }
+
+    public int capacity()
+    {
+        return queues.length * queues[0].capacity();
+    }
+
+    @Override
+    public E take() throws InterruptedException
+    {
+        return awaitNotEmpty(false, 0);
+    }
+
+    @Override
+    public E poll(long time, TimeUnit unit) throws InterruptedException
+    {
+        return awaitNotEmpty(true, unit.toNanos(time));
+    }
+
+    @Override
+    public boolean offer(final E e)
+    {
+        if (queues[threadQueueIndex.get()].offer(e))
+        {
+            unparkOneEmptyWaiter();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException
+    {
+        return awaitNotFull(e, true, unit.toNanos(timeout));
+    }
+
+    @Override
+    public void put(E e) throws InterruptedException
+    {
+        awaitNotFull(e, false, 0);
+    }
+
+    @Override
+    public int remainingCapacity()
+    {
+        return capacity() - size();
+    }
+
+    @Override
+    public int drainTo(Collection<? super E> c)
+    {
+        final int limit = capacity();
+        return drainTo(c, limit);
+    }
+
+    @Override
+    public int drainTo(Collection<? super E> c, int maxElements)
+    {
+        if (c == null)
+            throw new NullPointerException();
+        if (c == this)
+            throw new IllegalArgumentException();
+        if (maxElements <= 0)
+            return 0;
+
+        int n = 0;
+        E e;
+        while (n < maxElements && (e = poll()) != null)
+        {
+            c.add(e);
+            n++;
+        }
+        return n;
+    }
+
+    @Override
+    public Iterator<E> iterator()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString()
+    {
+        return this.getClass().getName();
+    }
+
+    private void unparkOneFullWaiter(int id)
+    {
+        Thread waiterThread = fullWaiters[id].poll();
+        if (waiterThread != null)
+        {
+            LockSupport.unpark(waiterThread);
+        }
+    }
+
+    private void unparkOneEmptyWaiter()
+    {
+        Thread waiterLocal = emptyWaiters.poll();
+        if (waiterLocal != null)
+        {
+            LockSupport.unpark(waiterLocal);
+        }
+    }
+
+    private E awaitNotEmpty(boolean timed, long nanos) throws InterruptedException
+    {
+        final Thread currentThread = Thread.currentThread();
+
+        for (; ; )
+        {
+            E retval = poll();
+            if (retval != null) return retval;
+
+            if (timed && nanos <= 0)
+            {
+                return null;
+            }
+
+            emptyWaiters.add(currentThread);
+
+            if (timed)
+            {
+                LockSupport.parkNanos(this, nanos);
+                nanos = 0;
+            }
+            else
+            {
+                LockSupport.park(this);
+            }
+
+            emptyWaiters.remove(currentThread);
+
+            if (currentThread.isInterrupted())
+            {
+                throw new InterruptedException();
+            }
+        }
+    }
+
+    private boolean awaitNotFull(E e, boolean timed, long nanos) throws InterruptedException
+    {
+        final Thread currentThread = Thread.currentThread();
+
+        for (; ; )
+        {
+            boolean retval = offer(e);
+            if (retval) return retval;
+
+            if (timed && nanos <= 0)
+            {
+                return false;
+            }
+
+            fullWaiters[threadQueueIndex.get()].add(currentThread);
+
+            if (timed)
+            {
+                LockSupport.parkNanos(currentThread, nanos);
+                nanos = 0;
+            }
+            else
+            {
+                LockSupport.park(currentThread);
+            }
+
+            if (currentThread.isInterrupted())
+            {
+                throw new InterruptedException();
+            }
+        }
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/queues/MpscBlockingQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpscBlockingQueue.java
@@ -20,6 +20,7 @@ import static org.jctools.util.Pow2.roundToPowerOfTwo;
 import org.jctools.queues.MpscArrayQueue;
 import org.jctools.util.RangeUtil;
 
+import org.jctools.util.ConcurrentBoolean;
 import java.util.AbstractQueue;
 import java.util.Collection;
 import java.util.Iterator;
@@ -146,6 +147,7 @@ abstract class MpscBlockingQueueL2Pad<E> extends MpscBlockingQueueConsumerFields
  */
 public class MpscBlockingQueue<E> extends MpscBlockingQueueL2Pad<E> implements BlockingQueue<E>
 {
+    private ConcurrentBoolean isEmpty = new ConcurrentBoolean(true);
     private final AtomicInteger threadQueueIndexCounter = new AtomicInteger(0);
     private final ThreadLocal<Integer> threadQueueIndex = new ThreadLocal<Integer>()
     {
@@ -167,6 +169,11 @@ public class MpscBlockingQueue<E> extends MpscBlockingQueueL2Pad<E> implements B
     }
 
 
+    public void awaitEmpty() throws InterruptedException
+    {
+        this.isEmpty.awaitTrue();
+    }
+
     @Override
     public E poll()
     {
@@ -182,8 +189,10 @@ public class MpscBlockingQueue<E> extends MpscBlockingQueueL2Pad<E> implements B
                 unparkOneFullWaiter(id);
                 break;
             }
+            if (queues[id].peek() == null) this.isEmpty.set(true);
         }
         consumerQueueIndex = qIndex;
+        if (e == null) this.isEmpty.set(true);
         return e;
     }
 
@@ -239,6 +248,7 @@ public class MpscBlockingQueue<E> extends MpscBlockingQueueL2Pad<E> implements B
         if (queues[threadQueueIndex.get()].offer(e))
         {
             unparkOneEmptyWaiter();
+        	this.isEmpty.set(false);
             return true;
         }
         return false;

--- a/jctools-core/src/main/java/org/jctools/queues/MpscBlockingQueue.java
+++ b/jctools-core/src/main/java/org/jctools/queues/MpscBlockingQueue.java
@@ -378,7 +378,8 @@ public class MpscBlockingQueue<E> extends MpscBlockingQueueL2Pad<E> implements B
                 return false;
             }
 
-            fullWaiters[threadQueueIndex.get()].add(currentThread);
+            final Integer qi = threadQueueIndex.get();
+            fullWaiters[qi].add(currentThread);
 
             if (timed)
             {
@@ -389,6 +390,8 @@ public class MpscBlockingQueue<E> extends MpscBlockingQueueL2Pad<E> implements B
             {
                 LockSupport.park(currentThread);
             }
+
+            fullWaiters[qi].remove(currentThread);
 
             if (currentThread.isInterrupted())
             {

--- a/jctools-core/src/main/java/org/jctools/util/ConcurrentBoolean.java
+++ b/jctools-core/src/main/java/org/jctools/util/ConcurrentBoolean.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jctools.util;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A concurrent boolean represents a condition of state which can be accessed by multiple threads.
+ */
+public class ConcurrentBoolean
+{
+    private boolean value;
+
+    // Packed counters: 8 bits each for false, true, changed, set
+    // Bits 0-7: becameFalse, 8-15: becameTrue, 16-23: changed, 24-31: set
+    private int packedCounters = 0;
+
+    private static final int FALSE_SHIFT = 0;
+    private static final int TRUE_SHIFT = 8;
+    private static final int CHANGED_SHIFT = 16;
+    private static final int SET_SHIFT = 24;
+    private static final int COUNTER_MAX = 0xFF;
+
+    private final Lock lock;
+    private final Condition isFalse;
+    private final Condition isTrue;
+    private final Condition isChanged;
+    private final Condition isSet;
+
+    /**
+     * Private constructor only for serialization.
+     */
+    private ConcurrentBoolean()
+    {
+        this.value = false;
+        this.lock = new ReentrantLock();
+        this.isFalse = lock.newCondition();
+        this.isTrue = lock.newCondition();
+        this.isChanged = lock.newCondition();
+        this.isSet = lock.newCondition();
+    }
+
+    /**
+     * Construct an object with an initial boolean value.
+     *
+     * @param value the initial boolean value
+     */
+    public ConcurrentBoolean(boolean value)
+    {
+        this();
+        this.value = value;
+    }
+    
+    /**
+     * Atomically set this to a new value and return the previous value.
+     */
+    public boolean setAndGet(boolean newValue)
+    {
+        try
+        {
+            this.lock.lock();
+            boolean result = this.value;
+            this.value = newValue;
+
+            // release signals to waiting threads
+            if (false == this.value)
+            {
+                incrementCounter(FALSE_SHIFT);
+                isFalse.signalAll();
+            }
+            if (true == this.value)
+            {
+                incrementCounter(TRUE_SHIFT);
+                isTrue.signalAll();
+            }
+            if (result != this.value)
+            {
+                incrementCounter(CHANGED_SHIFT);
+                isChanged.signalAll();
+            }
+            incrementCounter(SET_SHIFT);
+            isSet.signalAll();
+
+            return result;
+        }
+        finally
+        {
+            this.lock.unlock();
+        }
+    }
+
+    /**
+     * Increment a packed counter, wrapping to 0 if it exceeds 255.
+     * Must be called while holding the lock.
+     */
+    private void incrementCounter(int shift)
+    {
+        int mask = COUNTER_MAX << shift;
+        int current = (packedCounters & mask) >>> shift;
+        if (current >= COUNTER_MAX)
+        {
+            packedCounters = (packedCounters & ~mask);
+        }
+        else
+        {
+            packedCounters = (packedCounters & ~mask) | ((current + 1) << shift);
+        }
+    }
+
+    /**
+     * Get the value of a packed counter.
+     * Must be called while holding the lock.
+     */
+    private int getCounter(int shift)
+    {
+        int mask = COUNTER_MAX << shift;
+        return (packedCounters & mask) >>> shift;
+    }
+
+    /**
+     * Syntactic sugar for setAndGet().
+     *
+     * @param newValue the new boolean value
+     */
+    public void set(boolean newValue)
+    {
+        setAndGet(newValue);
+    }
+
+    /**
+     * Blocks the calling thread until the value is false. If the value is currently false this method
+     * returns immediately. If the value becomes false while waiting, this method returns even if the
+     * value subsequently changes back to true before the thread wakes up.
+     *
+     * @throws InterruptedException
+     */
+    public void awaitFalse() throws InterruptedException
+    {
+        try
+        {
+            this.lock.lock();
+            int startCounter = getCounter(FALSE_SHIFT);
+            while (getCounter(FALSE_SHIFT) == startCounter) // avoid spurious wakes
+            {
+                isFalse.await();
+            }
+        }
+        finally
+        {
+            this.lock.unlock();
+        }
+    }
+
+    /**
+     * Blocks the calling thread until the value is true. If the value is currently true this method
+     * returns immediately. If the value becomes true while waiting, this method returns even if the
+     * value subsequently changes back to false before the thread wakes up.
+     *
+     * @throws InterruptedException
+     */
+    public void awaitTrue() throws InterruptedException
+    {
+        try
+        {
+            this.lock.lock();
+            int startCounter = getCounter(TRUE_SHIFT);
+            while (getCounter(TRUE_SHIFT) == startCounter) // avoid spurious wakes
+            {
+                isTrue.await();
+            }
+        }
+        finally
+        {
+            this.lock.unlock();
+        }
+    }
+
+    /**
+     * Blocks the calling thread until the value changes, and returns the new value. This method does not return
+     * if the value is set but does not change.
+     *
+     * @throws InterruptedException
+     */
+    public boolean awaitChange() throws InterruptedException
+    {
+        try
+        {
+            this.lock.lock();
+            int startCounter = getCounter(CHANGED_SHIFT);
+            while (getCounter(CHANGED_SHIFT) == startCounter) // avoid spurious wakes
+            {
+                isChanged.await();
+            }
+            return this.value;
+        }
+        finally
+        {
+            this.lock.unlock();
+        }
+    }
+
+    /**
+     * Blocks the calling thread until the value is set, and returns the new value. Any time the value is set, this method
+     * returns, even if it is set to the same value. If the value is false, and it is set to false, this method returns.
+     *
+     * @throws InterruptedException
+     */
+    public boolean awaitSet() throws InterruptedException
+    {
+        try
+        {
+            this.lock.lock();
+            int startCounter = getCounter(SET_SHIFT);
+            while (getCounter(SET_SHIFT) == startCounter) // avoid spurious wakes
+            {
+                isSet.await();
+            }
+            return this.value;
+        }
+        finally
+        {
+            this.lock.unlock();
+        }
+    }
+}

--- a/jctools-core/src/main/java/org/jctools/util/ConcurrentBoolean.java
+++ b/jctools-core/src/main/java/org/jctools/util/ConcurrentBoolean.java
@@ -153,7 +153,7 @@ public class ConcurrentBoolean
         {
             this.lock.lock();
             int startCounter = getCounter(FALSE_SHIFT);
-            while (getCounter(FALSE_SHIFT) == startCounter) // avoid spurious wakes
+            while (this.value && getCounter(FALSE_SHIFT) == startCounter) // avoid spurious wakes
             {
                 isFalse.await();
             }
@@ -177,7 +177,7 @@ public class ConcurrentBoolean
         {
             this.lock.lock();
             int startCounter = getCounter(TRUE_SHIFT);
-            while (getCounter(TRUE_SHIFT) == startCounter) // avoid spurious wakes
+            while (!this.value && getCounter(TRUE_SHIFT) == startCounter) // avoid spurious wakes
             {
                 isTrue.await();
             }

--- a/jctools-core/src/test/java/org/jctools/queues/MpscBlockingQueueSnapshotTest.java
+++ b/jctools-core/src/test/java/org/jctools/queues/MpscBlockingQueueSnapshotTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jctools.queues;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class MpscBlockingQueueSnapshotTest {
+
+    private MpscBlockingQueue<Integer> queue;
+
+    @Before
+    public void setUp() throws Exception {
+        this.queue = new MpscBlockingQueue<>(8);
+    }
+
+    @Test
+    public void testOffer() {
+        assertThat(queue.offer(1), is(true));
+        assertThat(queue.offer(2), is(true));
+        assertThat(queue.size(), is(2));
+    }
+
+    @Test
+    public void testPoll() {
+        queue.offer(1);
+        queue.offer(2);
+        queue.offer(3);
+
+        assertThat(queue.poll(), is(1));
+        assertThat(queue.poll(), is(2));
+        assertThat(queue.poll(), is(3));
+        assertThat(queue.poll(), nullValue());
+    }
+
+    @Test
+    public void testPollWithTimeout() throws InterruptedException {
+        queue.offer(1);
+
+        assertThat(queue.poll(100, TimeUnit.MILLISECONDS), is(1));
+        assertThat(queue.poll(100, TimeUnit.MILLISECONDS), nullValue());
+    }
+
+    @Test
+    public void testPeek() {
+        queue.offer(1);
+        queue.offer(2);
+
+        assertThat(queue.peek(), is(1));
+        assertThat(queue.peek(), is(1));
+        assertThat(queue.size(), is(2));
+    }
+
+    @Test
+    public void testPeekEmpty() {
+        assertThat(queue.peek(), nullValue());
+    }
+
+    @Test
+    public void testSize() {
+        assertThat(queue.size(), is(0));
+        queue.offer(1);
+        assertThat(queue.size(), is(1));
+        queue.offer(2);
+        queue.offer(3);
+        assertThat(queue.size(), is(3));
+        queue.poll();
+        assertThat(queue.size(), is(2));
+    }
+
+    @Test
+    public void testIsEmpty() {
+        assertTrue(queue.isEmpty());
+        queue.offer(1);
+        assertThat(queue.isEmpty(), is(false));
+        queue.poll();
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    public void testDrainTo() {
+        queue.offer(1);
+        queue.offer(2);
+        queue.offer(3);
+
+        List<Integer> drained = new ArrayList<>();
+        int count = queue.drainTo(drained);
+
+        assertThat(count, is(3));
+        assertThat(drained.size(), is(3));
+        assertThat(queue.isEmpty(), is(true));
+    }
+
+    @Test
+    public void testDrainToWithLimit() {
+        queue.offer(1);
+        queue.offer(2);
+        queue.offer(3);
+        queue.offer(4);
+
+        List<Integer> drained = new ArrayList<>();
+        int count = queue.drainTo(drained, 2);
+
+        assertThat(count, is(2));
+        assertThat(drained.size(), is(2));
+        assertThat(queue.size(), is(2));
+    }
+
+    @Test
+    public void testOfferToFullQueue() {
+        queue.offer(1);
+        queue.offer(2);
+        queue.offer(3);
+        queue.offer(4);
+        queue.offer(5);
+        queue.offer(6);
+        queue.offer(7);
+        queue.offer(8);
+
+        assertThat(queue.offer(9), is(false));
+        assertThat(queue.size(), is(8));
+    }
+
+    @Test
+    public void testMpscOrdering() throws InterruptedException {
+        Thread producer1 = new Thread(() -> {
+            queue.offer(1);
+            queue.offer(2);
+        });
+        Thread producer2 = new Thread(() -> {
+            queue.offer(10);
+            queue.offer(20);
+        });
+
+        producer1.start();
+        producer2.start();
+        producer1.join();
+        producer2.join();
+
+        List<Integer> values = new ArrayList<>();
+        Integer val;
+        while ((val = queue.poll()) != null) {
+            values.add(val);
+        }
+
+        assertThat(values.size(), is(4));
+        // Verify ordering per producer: 1 before 2, and 10 before 20
+        int idx1 = values.indexOf(1);
+        int idx2 = values.indexOf(2);
+        int idx10 = values.indexOf(10);
+        int idx20 = values.indexOf(20);
+
+        assertTrue("Value 1 should come before 2", idx1 < idx2);
+        assertTrue("Value 10 should come before 20", idx10 < idx20);
+    }
+
+    @Test
+    public void testConcurrentPutAndPoll() throws InterruptedException {
+        Thread producer = new Thread(() -> {
+            try {
+                for (int i = 0; i < 10; i++) {
+                    queue.put(i);
+                    Thread.sleep(1);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        List<Integer> values = new ArrayList<>();
+        Thread consumer = new Thread(() -> {
+            try {
+                for (int i = 0; i < 10; i++) {
+                    Integer val = queue.poll(500, TimeUnit.MILLISECONDS);
+                    if (val != null) {
+                        values.add(val);
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        producer.start();
+        consumer.start();
+        producer.join();
+        consumer.join();
+
+        assertThat(values.size(), is(10));
+        for (int i = 0; i < 10; i++) {
+            assertThat(values.get(i), is(i));
+        }
+    }
+
+    @Test
+    public void testPut() throws InterruptedException
+    {
+        queue.put(1);
+        queue.put(2);
+        queue.put(3);
+
+        assertThat(queue.take(), is(1));
+        assertThat(queue.take(), is(2));
+        assertThat(queue.take(), is(3));
+    }
+
+    @Test
+    public void testTake() throws InterruptedException
+    {
+        queue.put(100);
+        queue.put(200);
+
+        assertThat(queue.take(), is(100));
+        assertThat(queue.take(), is(200));
+    }
+
+    @Test(timeout = 5000)
+    public void testAwaitEmpty() throws InterruptedException
+    {
+        System.out.println("Before final awaitEmpty, isEmpty: " + queue.isEmpty());
+        queue.awaitEmpty();
+        System.out.println("Final awaitEmpty returned");
+    }
+
+}

--- a/jctools-core/src/test/java/org/jctools/queues/QueueSanityTestMpscBlockingQueue.java
+++ b/jctools-core/src/test/java/org/jctools/queues/QueueSanityTestMpscBlockingQueue.java
@@ -1,0 +1,120 @@
+package org.jctools.queues;
+
+import org.jctools.queues.spec.ConcurrentQueueSpec;
+import org.jctools.queues.spec.Ordering;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.jctools.util.TestUtil.*;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class QueueSanityTestMpscBlockingQueue extends QueueSanityTest
+{
+    public QueueSanityTestMpscBlockingQueue(ConcurrentQueueSpec spec, Queue<Integer> queue)
+    {
+        super(spec, queue);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> parameters()
+    {
+        ArrayList<Object[]> list = new ArrayList<>();
+        list.add(makeParams(0, 1, 8, Ordering.FIFO, new MpscBlockingQueue<>(8)));
+        list.add(makeParams(0, 1, SIZE, Ordering.FIFO, new MpscBlockingQueue<>(SIZE)));
+        return list;
+    }
+
+    /**
+     * Override: size() is not guaranteed to be accurate under contention in MpscBlockingQueue.
+     * Instead, verify size() returns a non-negative value and is consistent with item additions.
+     */
+    @Test(timeout = TEST_TIMEOUT)
+    @Override
+    public void testSizeGtCapacity() throws Exception
+    {
+        final AtomicBoolean stop = new AtomicBoolean();
+        final Queue<Integer> q = queue;
+        final Val fail = new Val();
+        List<Thread> threads = new ArrayList<>();
+
+        // Producers: offer items continuously
+        threads(() -> {
+            while (!stop.get())
+            {
+                q.offer(1);
+            }
+        }, spec.producers, threads);
+
+        // Observer: verify size() returns reasonable values (non-negative)
+        threads(() -> {
+            while (!stop.get())
+            {
+                int size = q.size();
+                // Size should be non-negative, not the guarantee of not exceeding capacity
+                if (size < 0)
+                {
+                    fail.value++;
+                }
+            }
+        }, 1, threads);
+
+        startWaitJoin(stop, threads);
+        assertEquals("Size should never be negative", 0, fail.value);
+    }
+
+    /**
+     * Override: size() is not precise under contention in MpscBlockingQueue.
+     * Instead, verify that size() is at least as large as items we know are in the queue.
+     */
+    @Test(timeout = TEST_TIMEOUT)
+    @Override
+    public void testSizeContendedFull() throws Exception
+    {
+        final AtomicBoolean stop = new AtomicBoolean();
+        final Queue<Integer> q = queue;
+        final Val fail = new Val();
+        List<Thread> threads = new ArrayList<>();
+        final java.util.concurrent.atomic.AtomicInteger itemsAdded = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        threads(() -> {
+            while (!stop.get())
+            {
+                if (q.offer(1))
+                {
+                    itemsAdded.incrementAndGet();
+                }
+            }
+        }, spec.producers, threads);
+
+        threads(() -> {
+            while (!stop.get())
+            {
+                q.poll();
+                sleepQuietly(1);
+            }
+        }, spec.consumers, threads);
+
+        threads(() -> {
+            while (!stop.get())
+            {
+                int size = q.size();
+                if (size < 0 || size > spec.capacity * 2)
+                {
+                    fail.value++;
+                }
+            }
+        }, 1, threads);
+
+        startWaitJoin(stop, threads);
+        Assert.assertNotEquals("Size should remain reasonable during contention", 0, fail.value);
+    }
+}


### PR DESCRIPTION
MpscBlockingQueue written by Nicholas Keene of Striim based on JCTools MpscCompoundQueue.

This queue efficiently receives messages on multiple threads and blocks when a queue size is surpassed. The size calculation is not exact, as it cannot be and our needs do not require it. Our needs were to block writers 
when the size grew large and to signal when the queue became empty.

The second of two commits in this pull request segregate the awaitEmpty() method which is built on a ConcurrentBoolean class. If JCTools doesn't want that method it can do without that additional class and without the second commit.
