### PR TITLE
fix: JPMS module names incorrectly derived from OSGI bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,8 +190,10 @@
                 </dependencies>
                 <configuration>
                     <instructions>
-                        <!-- Adds a module descriptor named as the OSGI bundle -->
-                        <_jpms-module-info>$[maven-symbolicname];access=0</_jpms-module-info>
+                        <!-- Adds a module descriptor named as the OSGI bundle with dashes as dots -->
+                        <_jpms-module-info>${replace;$[maven-symbolicname];-;.};access=0</_jpms-module-info>
+                        <!-- Rewrite invalid dependency jctool-core into org.jctools.core -->
+                        <_jpms-module-info-options>org.jctools.core;substitute="jctools-core"</_jpms-module-info-options>
                         <!-- Exports only explicitly annotated packages -->
                         <_exportcontents>$[packages;ANNOTATED;org.osgi.annotation.bundle.Export]</_exportcontents>
                     </instructions>


### PR DESCRIPTION
Fixes #414 

Used https://bnd.bndtools.org/instructions/jpms_module_info_options.html, and https://bnd.bndtools.org/macros/replace.html